### PR TITLE
feat: improve history downloader with retries and synthetic data

### DIFF
--- a/scripts/download_history.py
+++ b/scripts/download_history.py
@@ -1,37 +1,169 @@
 from __future__ import annotations
-import argparse, time, os
-from datetime import datetime, timezone
-from src.data.ccxt_loader import get_exchange, fetch_ohlcv, simulate_1s_from_1m, save_history
 
-def parse_since(s: str | None):
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import List
+
+import ccxt
+import numpy as np
+import pandas as pd
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.append(ROOT)
+
+from src.utils.logging import ensure_logger
+from src.utils.data_io import save_ohlcv
+
+
+def parse_since(s: str | None) -> int | None:
     if not s:
         return None
-    # Try ISO date
     try:
-        dt = datetime.fromisoformat(s.replace("Z","")).replace(tzinfo=timezone.utc)
-        return int(dt.timestamp()*1000)
+        dt = datetime.fromisoformat(s.replace("Z", "")).replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
     except Exception:
         return None
 
-def main():
+
+def fetch_with_retries(
+    ex: ccxt.Exchange,
+    symbol: str,
+    timeframe: str,
+    since: int | None,
+    rate_limit: float,
+    retries: int,
+    logger,
+) -> List[List[float]]:
+    delay = rate_limit
+    for attempt in range(retries):
+        try:
+            time.sleep(rate_limit)
+            data = ex.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=1000)
+            return data
+        except Exception as e:  # ccxt.BaseError
+            logger.warning("fetch_retry", symbol=symbol, attempt=attempt + 1, error=str(e), wait=delay)
+            time.sleep(delay)
+            delay *= 2
+    logger.error("fetch_failed", symbol=symbol, timeframe=timeframe)
+    return []
+
+
+def download_ohlcv(
+    ex: ccxt.Exchange,
+    symbol: str,
+    timeframe: str,
+    since: int | None,
+    rate_limit: float,
+    retries: int,
+    logger,
+) -> pd.DataFrame:
+    all_rows: List[List[float]] = []
+    ms_per_tf = int(ex.parse_timeframe(timeframe) * 1000)
+    fetch_since = since
+    while True:
+        chunk = fetch_with_retries(ex, symbol, timeframe, fetch_since, rate_limit, retries, logger)
+        if not chunk:
+            break
+        all_rows.extend(chunk)
+        fetch_since = chunk[-1][0] + ms_per_tf
+        if len(chunk) < 1000:
+            break
+    columns = ["ts", "open", "high", "low", "close", "volume"]
+    return pd.DataFrame(all_rows, columns=columns)
+
+
+def synthesize_1s_from_1m(df_1m: pd.DataFrame, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    rows = []
+    for _, row in df_1m.iterrows():
+        base_ts = int(row["ts"])
+        base_open = row["open"]
+        base_close = row["close"]
+        base_volume = row["volume"] / 60.0
+        for i in range(60):
+            ts = base_ts + i * 1000
+            price = base_open + (base_close - base_open) * (i / 59 if 59 else 0)
+            noise = rng.normal(scale=0.0001 * price)
+            price = price + noise
+            rows.append([ts, price, price, price, price, base_volume])
+    return pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
+
+
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--exchange", type=str, default="binance")
     ap.add_argument("--symbols", nargs="+", required=True)
-    ap.add_argument("--timeframe", type=str, default="1m")
+    ap.add_argument("--timeframe", type=str, choices=["1m", "1s"], default="1m")
     ap.add_argument("--since", type=str, default=None, help="ISO date (UTC) p.ej. 2024-01-01")
     ap.add_argument("--root", type=str, default="data/raw")
+    ap.add_argument("--rate-limit", type=float, default=1.0, help="seconds between requests")
+    ap.add_argument("--retries", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=0, help="seed for synthetic data")
     args = ap.parse_args()
 
-    ex = get_exchange(args.exchange)
+    logger = ensure_logger(None)
+
     since_ms = parse_since(args.since)
+
     for sym in args.symbols:
-        df = fetch_ohlcv(ex, sym, timeframe=args.timeframe, since=since_ms)
+        ex_name = args.exchange
+        ex_class = getattr(ccxt, ex_name)
+        ex = ex_class({"enableRateLimit": True})
+        try:
+            ex.load_markets()
+        except Exception as e:
+            logger.warning("load_markets_failed", exchange=ex_name, error=str(e))
+            if ex_name == "binance":
+                logger.info("fallback_exchange", from_exchange=ex_name, to="kraken")
+                ex_name = "kraken"
+                ex = ccxt.kraken({"enableRateLimit": True})
+                try:
+                    ex.load_markets()
+                except Exception as e2:
+                    logger.error("load_markets_failed", exchange=ex_name, error=str(e2))
+                    continue
+            else:
+                continue
+
+        if ex_name == "binance" and sym not in ex.symbols:
+            logger.warning("symbol_not_found", exchange=ex_name, symbol=sym, fallback="kraken")
+            ex_name = "kraken"
+            ex = ccxt.kraken({"enableRateLimit": True})
+            try:
+                ex.load_markets()
+            except Exception as e:
+                logger.error("load_markets_failed", exchange=ex_name, error=str(e))
+                continue
+            if sym not in ex.symbols:
+                logger.error("symbol_not_found_any", symbol=sym)
+                continue
+
+        try:
+            df = download_ohlcv(ex, sym, args.timeframe, since_ms, args.rate_limit, args.retries, logger)
+        except Exception as e:
+            logger.error("download_failed", exchange=ex_name, symbol=sym, error=str(e))
+            continue
+
+        source = "exchange"
         if args.timeframe == "1s" and df.empty:
-            print(f"[WARN] 1s no disponible; simulando desde 1m para {sym}")
-            df_1m = fetch_ohlcv(ex, sym, timeframe="1m", since=since_ms)
-            df = simulate_1s_from_1m(df_1m)
-        path = save_history(df, args.root, args.exchange, sym, args.timeframe)
-        print(f"Guardado: {path}")
+            logger.warning("timeframe_unavailable", exchange=ex_name, symbol=sym, timeframe="1s")
+            df_1m = download_ohlcv(ex, sym, "1m", since_ms, args.rate_limit, args.retries, logger)
+            df = synthesize_1s_from_1m(df_1m, seed=args.seed)
+            source = "synthetic"
+
+        df["exchange"] = ex_name
+        df["symbol"] = sym
+        df["timeframe"] = args.timeframe
+        df["source"] = source
+
+        path = save_ohlcv(df, args.root, ex_name, sym, args.timeframe)
+        logger.info("saved", path=path, rows=len(df))
+
 
 if __name__ == "__main__":
     main()
+

--- a/src/utils/data_io.py
+++ b/src/utils/data_io.py
@@ -3,6 +3,19 @@ import os
 from typing import Optional
 import pandas as pd
 
+REQUIRED_OHLCV_COLUMNS = [
+    "ts",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "exchange",
+    "symbol",
+    "timeframe",
+    "source",
+]
+
 def ensure_dir(path: str):
     os.makedirs(path, exist_ok=True)
 
@@ -24,3 +37,26 @@ def load_table(path: str) -> pd.DataFrame:
         return pd.read_parquet(path)
     else:
         raise ValueError(f"Unsupported extension: {ext}")
+
+
+def validate_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
+    """Basic validation and UTC normalization for OHLCV tables."""
+    missing = set(REQUIRED_OHLCV_COLUMNS) - set(df.columns)
+    if missing:
+        raise ValueError(f"missing columns: {missing}")
+
+    df = df.copy()
+    df["ts"] = pd.to_datetime(df["ts"], utc=True, unit="ms")
+    df.sort_values("ts", inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    # store timestamps as integer milliseconds
+    df["ts"] = (df["ts"].astype("int64") // 1_000_000).astype("int64")
+    return df
+
+
+def save_ohlcv(df: pd.DataFrame, root: str, exchange: str, symbol: str, timeframe: str) -> str:
+    df = validate_ohlcv(df)
+    sym_fs = symbol.replace("/", "_")
+    path = os.path.join(root, exchange, sym_fs, f"{timeframe}.parquet")
+    save_table(df, path)
+    return path

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -17,6 +17,25 @@ class JsonLogger:
         else:
             print(line, file=sys.stdout)
 
+    # convenience wrappers -------------------------------------------------
+
+    def info(self, msg: str, **kwargs: Any):
+        self.log("info", msg, **kwargs)
+
+    def warning(self, msg: str, **kwargs: Any):
+        self.log("warning", msg, **kwargs)
+
+    def error(self, msg: str, **kwargs: Any):
+        self.log("error", msg, **kwargs)
+
+    # context manager support ----------------------------------------------
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
     def close(self):
         if self.fp:
             self.fp.close()


### PR DESCRIPTION
## Summary
- add JSON logger conveniences and context manager
- validate and save OHLCV data with UTC normalization
- enhance history downloader with retries, fallback to Kraken, 1s synthesis, and structured logging
- handle exchange market loading failures and auto-fallback when Binance is blocked

## Testing
- `python3 scripts/download_history.py --exchange binance --symbols BTC/USDT --timeframe 1m --since "2024-01-01"` *(fails: binance GET https://api.binance.com/api/v3/exchangeInfo)*
- `python3 scripts/download_history.py --exchange binance --symbols BTC/USDT --timeframe 1s --since "2024-01-01"` *(fails: binance GET https://api.binance.com/api/v3/exchangeInfo)*
- `python3 -m py_compile scripts/download_history.py src/utils/logging.py src/utils/data_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3c632914c83288ecb4884606f2c1e