### PR TITLE
feat: build liquid universe generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ reports/
 !src/data/
 !src/data/universe/
 !src/data/universe/liquid_universe.csv
+!src/env/
+!src/env/**
 
 # OS files
 .DS_Store

--- a/scripts/build_universe.py
+++ b/scripts/build_universe.py
@@ -110,6 +110,10 @@ def main() -> None:
 
     logger = ensure_logger(None)
 
+    # normalize the quote currency to uppercase so that comparisons are
+    # case-insensitive regardless of how the user provides the argument.
+    args.quote = args.quote.upper()
+
     if ccxt is None:
         raise RuntimeError("ccxt no instalado. `pip install ccxt`.")
 
@@ -129,7 +133,9 @@ def main() -> None:
     for sym, m in markets.items():
         if m.get("spot") is not True:
             continue
-        if m.get("quote") != args.quote:
+        # some exchanges may return the quote in lowercase; guard against it
+        quote = (m.get("quote") or "").upper()
+        if quote != args.quote:
             continue
         if not m.get("active", True):
             continue

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,8 @@
+"""Data loading helpers for the trading bot."""
+
+__all__ = [
+    "simulate_1s_from_1m",
+]
+
+from .ccxt_loader import simulate_1s_from_1m  # noqa: E402
+

--- a/src/data/ccxt_loader.py
+++ b/src/data/ccxt_loader.py
@@ -1,0 +1,48 @@
+"""CCXT data helpers.
+
+Currently only provides a tiny utility used in the tests to generate
+synthetic high frequency data from minute bars.  The function is kept
+lightweight to avoid heavy dependencies during testing.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def simulate_1s_from_1m(df_1m: pd.DataFrame) -> pd.DataFrame:
+    """Expand 1 minute OHLCV data into 1 second bars.
+
+    The implementation performs a simple linear interpolation between the
+    open and close of each minute bar and divides the volume evenly.  It is
+    intended purely for testing and does not attempt to model real market
+    micro-structure.
+    """
+
+    rows = []
+    for _, row in df_1m.iterrows():
+        start_ts = int(row["ts"])
+        open_ = float(row["open"])
+        close = float(row["close"])
+        volume = float(row.get("volume", 0.0)) / 60.0
+        for i in range(60):
+            ts = start_ts + i * 1000
+            # simple linear interpolation for the price
+            if 59 > 0:
+                frac = i / 59.0
+            else:
+                frac = 0.0
+            price = open_ + (close - open_) * frac
+            rows.append(
+                {
+                    "ts": ts,
+                    "open": price,
+                    "high": price,
+                    "low": price,
+                    "close": price,
+                    "volume": volume,
+                }
+            )
+
+    return pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
+

--- a/src/env/__init__.py
+++ b/src/env/__init__.py
@@ -1,0 +1,4 @@
+"""Simple trading environment used for smoke tests."""
+
+from .trading_env import TradingEnv  # noqa: F401
+

--- a/src/env/trading_env.py
+++ b/src/env/trading_env.py
@@ -1,0 +1,49 @@
+"""Minimal trading environment.
+
+This is intentionally lightweight and only provides the tiny subset of
+functionality required for the unit tests.  It is **not** intended to be a
+full featured trading simulation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple, Dict, Any
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class _Space:
+    """Simple stand-in for a gym ``Space`` object."""
+
+    shape: Tuple[int, ...]
+
+
+class TradingEnv:
+    def __init__(self, df: pd.DataFrame):
+        self.df = df.reset_index(drop=True)
+        self.current_step = 0
+        # observation consists of OHLCV values
+        self.observation_space = _Space((5,))
+
+    # ------------------------------------------------------------------
+    def _get_obs(self, step: int) -> np.ndarray:
+        row = self.df.loc[step, ["open", "high", "low", "close", "volume"]]
+        return row.to_numpy(dtype=float)
+
+    # public API -------------------------------------------------------
+    def reset(self) -> Tuple[np.ndarray, Dict[str, Any]]:
+        self.current_step = 0
+        return self._get_obs(self.current_step), {}
+
+    def step(self, action: int) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+        prev_close = float(self.df.loc[self.current_step, "close"])
+        self.current_step += 1
+        done = self.current_step >= len(self.df) - 1
+        curr_close = float(self.df.loc[self.current_step, "close"])
+        reward = float(curr_close - prev_close)
+        obs = self._get_obs(self.current_step)
+        return obs, reward, done, False, {}
+

--- a/src/utils/data_io.py
+++ b/src/utils/data_io.py
@@ -16,10 +16,12 @@ REQUIRED_OHLCV_COLUMNS = [
     "source",
 ]
 
-def ensure_dir(path: str):
+def ensure_dir(path: str) -> None:
+    """Create ``path`` if it does not already exist."""
     os.makedirs(path, exist_ok=True)
 
-def save_table(df: pd.DataFrame, path: str):
+def save_table(df: pd.DataFrame, path: str) -> None:
+    """Save ``df`` to ``path`` inferring the format from the extension."""
     ensure_dir(os.path.dirname(path))
     ext = os.path.splitext(path)[1].lower()
     if ext == ".csv":
@@ -58,6 +60,15 @@ def save_universe(df: pd.DataFrame, path: str) -> str:
     df = df[UNIVERSE_COLUMNS].copy()
     save_table(df, path)
     return path
+
+
+def load_universe(path: str) -> pd.DataFrame:
+    """Load a previously saved universe table ensuring column order."""
+    df = load_table(path)
+    missing = set(UNIVERSE_COLUMNS) - set(df.columns)
+    if missing:
+        raise ValueError(f"missing columns: {missing}")
+    return df[UNIVERSE_COLUMNS].copy()
 
 
 def validate_ohlcv(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- generate liquid trading universe from ccxt with volume, age, and history filters
- add data i/o helpers for saving/loading universes
- provide minimal data loader and trading environment for tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d005b858832888439231273c28bc