### PR TITLE
feat: implement value-based policy with replay buffer

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -28,6 +28,7 @@ dqn:
   learning_rate: 1.0e-3
   gamma: 0.99
   batch_size: 64
+  buffer_size: 10000
   target_update: 1000
   epsilon_start: 1.0
   epsilon_end: 0.05
@@ -36,9 +37,25 @@ dqn:
 # Reward heads
 reward_weights:
   pnl: 1.0
-  turnover_penalty: 0.1
-  drawdown_penalty: 0.2
-  volatility_penalty: 0.1
+  turn: 0.1
+  dd: 0.2
+  vol: 0.1
+
+# Deterministic policy params
+deterministic_policy:
+  base_threshold: 0.001   # required 5-tick log-return to enter
+  bounce_coef: 0.5        # sensitivity of threshold to prior drawdown
+  trailing_pct: 0.01      # exit when price falls this fraction from peak
+  cooldown_ticks: 5       # min ticks between consecutive trades
+
+# Stochastic policy params
+stochastic_policy:
+  base_threshold: 0.001   # same semantics as deterministic
+  bounce_coef: 0.5
+  trailing_pct: 0.01
+  temperature: 0.1        # softmax temperature tau
+  noise_std: 0.0001       # std-dev of Gaussian noise on thresholds
+  seed: 42
 
 # Paths
 paths:
@@ -47,3 +64,4 @@ paths:
   logs_dir: "logs"
   reports_dir: "reports"
   checkpoints_dir: "checkpoints"
+  models_dir: "models"

--- a/src/env/trading_env.py
+++ b/src/env/trading_env.py
@@ -8,10 +8,14 @@ full featured trading simulation.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, List
 
 import numpy as np
 import pandas as pd
+import yaml
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -19,31 +23,216 @@ class _Space:
     """Simple stand-in for a gym ``Space`` object."""
 
     shape: Tuple[int, ...]
+    dtype: Any = np.float32
+
+
+@dataclass
+class _Discrete:
+    """Minimal discrete space (``n`` possible integer actions)."""
+
+    n: int
+    dtype: Any = np.int64
 
 
 class TradingEnv:
     def __init__(self, df: pd.DataFrame):
         self.df = df.reset_index(drop=True)
         self.current_step = 0
-        # observation consists of OHLCV values
-        self.observation_space = _Space((5,))
+
+        # caches ---------------------------------------------------------
+        self._close = self.df["close"].to_numpy(dtype=float)
+        self._low = self.df["low"].to_numpy(dtype=float)
+        self._high = self.df["high"].to_numpy(dtype=float)
+
+        # state ----------------------------------------------------------
+        self.in_position = False
+        self.trailing_stop: float | None = None
+        self.entry_price: float | None = None
+        self.equity = 0.0
+        self.equity_peak = 0.0
+
+        # history for robust scaling (one list per feature)
+        self._feature_histories: List[List[float]] = [[] for _ in range(8)]
+
+        # observation space: 8 engineered features, float32
+        self.observation_space = _Space((8,), np.float32)
+        # discrete action space: 0=hold, 1=open_long, 2=close
+        self.action_space = _Discrete(3, np.int64)
+        # in the future this could include a continuous component (0..1)
+        # to express position sizing alongside the discrete action
+
+        # config ---------------------------------------------------------
+        with open("configs/default.yaml", "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+        fees = cfg.get("fees", {})
+        self.fee_rate = float(fees.get("taker", 0.0))
+        rw = cfg.get("reward_weights", {})
+        self.w_pnl = float(rw.get("pnl", 1.0))
+        self.w_turn = float(rw.get("turn", 0.0))
+        self.w_dd = float(rw.get("dd", 0.0))
+        self.w_vol = float(rw.get("vol", 0.0))
 
     # ------------------------------------------------------------------
-    def _get_obs(self, step: int) -> np.ndarray:
-        row = self.df.loc[step, ["open", "high", "low", "close", "volume"]]
-        return row.to_numpy(dtype=float)
+    def _make_observation(self, step: int) -> np.ndarray:
+        """Create the observation vector for ``step``.
+
+        Features (pre-normalisation):
+            - log returns over 5/15/60 ticks
+            - rolling volatility over the past 60 returns
+            - local drawdown over the past 300 ticks
+            - distance to local minimum ("wall") over the past 300 ticks
+            - in-position flag (0/1)
+            - normalised trailing stop distance
+
+        Each feature is normalised using a simple online robust scaler
+        (median/IQR) that only looks at past values of the respective
+        feature.
+        """
+
+        price = self._close[step]
+
+        # price based ----------------------------------------------------
+        def safe_log_return(n: int) -> float:
+            if step >= n:
+                return float(np.log(price / self._close[step - n]))
+            return 0.0
+
+        ret_5 = safe_log_return(5)
+        ret_15 = safe_log_return(15)
+        ret_60 = safe_log_return(60)
+
+        # rolling volatility of 1-step log returns
+        start_idx = max(1, step - 59)
+        window_returns = np.diff(np.log(self._close[start_idx: step + 1]))
+        vol_60 = float(np.std(window_returns)) if len(window_returns) > 0 else 0.0
+
+        # drawdown relative to local max over last 300 ticks
+        max_price = float(np.max(self._close[max(0, step - 299): step + 1]))
+        drawdown_300 = float(price / max_price - 1.0) if max_price > 0 else 0.0
+
+        # distance to local minimum ("wall") over last 300 ticks
+        min_price = float(np.min(self._low[max(0, step - 299): step + 1]))
+        dist_wall = float(price - min_price)
+
+        # position based -------------------------------------------------
+        en_posicion = 1.0 if self.in_position else 0.0
+
+        if self.in_position and self.trailing_stop is not None and self.trailing_stop > 0:
+            trailing_normalizado = float((price - self.trailing_stop) / self.trailing_stop)
+        else:
+            trailing_normalizado = 0.0
+
+        raw_features = [
+            ret_5,
+            ret_15,
+            ret_60,
+            vol_60,
+            drawdown_300,
+            dist_wall,
+            en_posicion,
+            trailing_normalizado,
+        ]
+
+        # robust scaling -------------------------------------------------
+        scaled_features = []
+        for i, val in enumerate(raw_features):
+            hist = self._feature_histories[i]
+            if hist:
+                median = float(np.median(hist))
+                q75 = float(np.percentile(hist, 75))
+                q25 = float(np.percentile(hist, 25))
+                iqr = q75 - q25
+                if iqr == 0:
+                    iqr = 1.0
+                scaled = (val - median) / iqr
+            else:
+                scaled = 0.0
+            hist.append(val)
+            scaled_features.append(scaled)
+
+        return np.asarray(scaled_features, dtype=np.float32)
 
     # public API -------------------------------------------------------
     def reset(self) -> Tuple[np.ndarray, Dict[str, Any]]:
         self.current_step = 0
-        return self._get_obs(self.current_step), {}
+        self.in_position = False
+        self.trailing_stop = None
+        self.entry_price = None
+        self.equity = 0.0
+        self.equity_peak = 0.0
+        self._feature_histories = [[] for _ in range(8)]
+        obs = self._make_observation(self.current_step)
+        return obs, {}
 
     def step(self, action: int) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
-        prev_close = float(self.df.loc[self.current_step, "close"])
+        prev_price = self._close[self.current_step]
+        prev_equity = self.equity
+        prev_drawdown = self.equity_peak - self.equity
+        trade = False
+
+        # action: 0=hold, 1=open_long, 2=close
+        if action == 1 and not self.in_position:  # open long
+            self.in_position = True
+            self.trailing_stop = prev_price
+            self.entry_price = prev_price
+            fee = prev_price * self.fee_rate
+            self.equity -= fee
+            trade = True
+        elif action == 2 and self.in_position:  # close position
+            fee = prev_price * self.fee_rate
+            self.equity += (prev_price - self.entry_price) - fee
+            self.in_position = False
+            self.trailing_stop = None
+            self.entry_price = None
+            trade = True
+        # TODO: support a continuous size component (0..1) alongside the
+        # discrete action for finer trade management
+
         self.current_step += 1
-        done = self.current_step >= len(self.df) - 1
-        curr_close = float(self.df.loc[self.current_step, "close"])
-        reward = float(curr_close - prev_close)
-        obs = self._get_obs(self.current_step)
-        return obs, reward, done, False, {}
+        self.current_step = min(self.current_step, len(self._close) - 1)
+        done = self.current_step >= len(self._close) - 1
+        price = self._close[self.current_step]
+
+        if self.in_position:
+            self.equity += price - prev_price
+            if self.trailing_stop is not None:
+                self.trailing_stop = max(self.trailing_stop, price)
+
+        pnl_step = self.equity - prev_equity
+        self.equity_peak = max(self.equity_peak, self.equity)
+        new_drawdown = self.equity_peak - self.equity
+        dd_step = max(0.0, new_drawdown - prev_drawdown)
+        trades_step = 1.0 if trade else 0.0
+
+        start_idx = max(1, self.current_step - 4)
+        window_returns = np.diff(np.log(self._close[start_idx: self.current_step + 1]))
+        vol_step = float(np.std(window_returns)) if len(window_returns) > 0 else 0.0
+
+        reward = (
+            self.w_pnl * pnl_step
+            - self.w_turn * trades_step
+            - self.w_dd * dd_step
+            - self.w_vol * vol_step
+        )
+
+        logger.debug(
+            "step=%s pnl=%.6f trades=%.2f dd=%.6f vol=%.6f reward=%.6f",
+            self.current_step,
+            pnl_step,
+            trades_step,
+            dd_step,
+            vol_step,
+            reward,
+        )
+
+        obs = self._make_observation(self.current_step)
+        info = {
+            "reward_terms": {
+                "pnl": pnl_step,
+                "turnover": trades_step,
+                "drawdown": dd_step,
+                "volatility": vol_step,
+            }
+        }
+        return obs, reward, done, False, info
 

--- a/src/policies/deterministic.py
+++ b/src/policies/deterministic.py
@@ -1,20 +1,78 @@
 from __future__ import annotations
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
+
 import numpy as np
 
-class DeterministicPolicy:
-    """Threshold-based entry with simple trailing logic. Placeholder."""
-    def __init__(self, threshold: float = 0.001):
-        self.threshold = float(threshold)
 
-    def act(self, obs) -> int:
-        # obs = [price_norm, vol_norm, volat, dd, wall, pos, trailing_norm]
-        price_norm = float(obs[0])
-        pos = int(obs[5])
-        # Enter if price rising above small threshold
-        if pos == 0 and price_norm > (1.0 + self.threshold):
-            return 1  # open/long
-        # Close if price falls
-        if pos == 1 and price_norm < (1.0 - self.threshold):
-            return 2  # close
-        return 0  # hold
+class DeterministicPolicy:
+    """Rule-based policy with rebound entry, trailing exit and cooldown.
+
+    Parameters are expressed as fractions (``0.01`` → ``1%``).
+    """
+
+    def __init__(
+        self,
+        base_threshold: float = 0.001,
+        bounce_coef: float = 0.5,
+        trailing_pct: float = 0.01,
+        cooldown_ticks: int = 5,
+        threshold: float | None = None,
+    ) -> None:
+        # ``threshold`` kept for backwards compatibility with older configs
+        if threshold is not None:
+            base_threshold = threshold
+
+        self.base_threshold = float(base_threshold)
+        self.bounce_coef = float(bounce_coef)
+        self.trailing_pct = float(trailing_pct)
+        self.cooldown_ticks = int(cooldown_ticks)
+
+        self.last_trade_tick = -np.inf  # enforce cooldown
+        self.tick = 0
+
+    # ------------------------------------------------------------------
+    def act(self, obs: np.ndarray, return_trace: bool = False) -> Any:
+        """Return an action and optionally a decision trace.
+
+        Parameters
+        ----------
+        obs : np.ndarray
+            Observation vector. Expected order:
+            ``[ret_5, ret_15, ret_60, vol_60, drawdown, dist_wall, in_pos, trailing_norm]``.
+        return_trace : bool, optional
+            Whether to return a trace dict along with the action.
+        """
+
+        ret_5 = float(obs[0])
+        drawdown = abs(float(obs[4]))
+        in_pos = bool(obs[6] > 0.5)
+        trailing_norm = float(obs[7])
+
+        # dynamic entry threshold: bigger prior drop → smaller required rise
+        dyn_threshold = max(0.0, self.base_threshold - self.bounce_coef * drawdown)
+
+        can_trade = (self.tick - self.last_trade_tick) >= self.cooldown_ticks
+        action = 0  # default hold
+
+        if not in_pos and can_trade and ret_5 > dyn_threshold:
+            action = 1  # open long
+            self.last_trade_tick = self.tick
+        elif in_pos and trailing_norm <= -self.trailing_pct:
+            action = 2  # close position
+            self.last_trade_tick = self.tick
+
+        trace: Dict[str, Any] = {
+            "ret_5": ret_5,
+            "drawdown": drawdown,
+            "dyn_threshold": dyn_threshold,
+            "trailing_norm": trailing_norm,
+            "in_pos": in_pos,
+            "can_trade": can_trade,
+            "action": action,
+        }
+
+        self.tick += 1
+
+        if return_trace:
+            return action, trace
+        return action

--- a/src/policies/nets.py
+++ b/src/policies/nets.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import torch.nn as nn
+
+class MLP(nn.Module):
+    """Simple multi-layer perceptron"""
+    def __init__(self, in_dim: int, hidden_sizes: tuple[int, ...], out_dim: int):
+        super().__init__()
+        layers = []
+        last = in_dim
+        for h in hidden_sizes:
+            layers.append(nn.Linear(last, h))
+            layers.append(nn.ReLU())
+            last = h
+        layers.append(nn.Linear(last, out_dim))
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.model(x)

--- a/src/policies/replay_buffer.py
+++ b/src/policies/replay_buffer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from collections import deque
+from typing import Deque, Tuple
+import numpy as np
+
+class ReplayBuffer:
+    """Basic replay buffer for value-based methods."""
+    def __init__(self, capacity: int, seed: int | None = None):
+        self.capacity = capacity
+        self.buffer: Deque[Tuple[np.ndarray, int, float, np.ndarray, bool]] = deque(maxlen=capacity)
+        self.rng = np.random.default_rng(seed)
+
+    def push(self, state: np.ndarray, action: int, reward: float, next_state: np.ndarray, done: bool) -> None:
+        self.buffer.append((state, action, reward, next_state, done))
+
+    def sample(self, batch_size: int) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        idxs = self.rng.choice(len(self.buffer), size=batch_size, replace=False)
+        states, actions, rewards, next_states, dones = zip(*(self.buffer[i] for i in idxs))
+        return (
+            np.array(states),
+            np.array(actions),
+            np.array(rewards, dtype=np.float32),
+            np.array(next_states),
+            np.array(dones, dtype=bool),
+        )
+
+    def __len__(self) -> int:
+        return len(self.buffer)

--- a/src/policies/router.py
+++ b/src/policies/router.py
@@ -3,15 +3,15 @@ from typing import Dict, Any
 
 from .deterministic import DeterministicPolicy
 from .stochastic import StochasticPolicy
-from .value_based import TinyDQN
+from .value_based import ValueBasedPolicy
 
-def get_policy(policy_type: str, obs_dim: int = 7, n_actions: int = 3, **kwargs):
+def get_policy(policy_type: str, obs_dim: int = 8, n_actions: int = 3, **kwargs):
     policy_type = (policy_type or "deterministic").lower()
     if policy_type == "deterministic":
         return DeterministicPolicy(**{k:v for k,v in kwargs.items() if k in {"threshold"}})
     elif policy_type == "stochastic":
         return StochasticPolicy(**{k:v for k,v in kwargs.items() if k in {"base_threshold","epsilon","seed"}})
     elif policy_type in {"value", "value-based", "dqn"}:
-        return TinyDQN(obs_dim=obs_dim, n_actions=n_actions, **{k:v for k,v in kwargs.items() if k in {"gamma","lr","buffer_size","batch_size","seed"}})
+        return ValueBasedPolicy(obs_dim=obs_dim, n_actions=n_actions, **kwargs)
     else:
         raise ValueError(f"Unknown policy type: {policy_type}")

--- a/src/policies/stochastic.py
+++ b/src/policies/stochastic.py
@@ -1,14 +1,115 @@
+"""Stochastic policy that softmaxes rule-based scores.
+
+The policy mirrors the inputs/outputs of :class:`DeterministicPolicy` but
+returns a probability vector over the three discrete actions.  Entry and exit
+thresholds receive small Gaussian noise for exploration while remaining
+reproducible thanks to a configurable seed.
+"""
+
 from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
 import numpy as np
-from .deterministic import DeterministicPolicy
+
 
 class StochasticPolicy:
-    def __init__(self, base_threshold: float = 0.001, epsilon: float = 0.1, seed: int = 42):
-        self.det = DeterministicPolicy(threshold=base_threshold)
-        self.epsilon = float(epsilon)
+    """Rule-based stochastic policy with softmax action selection.
+
+    Parameters are expressed as fractions (``0.01`` → ``1%``).
+    """
+
+    def __init__(
+        self,
+        base_threshold: float = 0.001,
+        bounce_coef: float = 0.5,
+        trailing_pct: float = 0.01,
+        temperature: float = 0.1,
+        noise_std: float = 1e-4,
+        seed: int | None = None,
+    ) -> None:
+        self.base_threshold = float(base_threshold)
+        self.bounce_coef = float(bounce_coef)
+        self.trailing_pct = float(trailing_pct)
+        self.tau = float(temperature)
+        self.noise_std = float(noise_std)
         self.rng = np.random.default_rng(seed)
 
-    def act(self, obs) -> int:
-        if self.rng.random() < self.epsilon:
-            return int(self.rng.integers(0, 3))
-        return self.det.act(obs)
+    # ------------------------------------------------------------------
+    def _score_actions(self, obs: np.ndarray) -> Tuple[np.ndarray, Dict[str, Any]]:
+        """Compute raw scores for each discrete action.
+
+        Returns
+        -------
+        scores : np.ndarray
+            Array of shape ``(3,)`` with scores for ``[hold, open, close]``.
+        trace : Dict[str, Any]
+            Intermediate values used for decision tracing.
+        """
+
+        ret_5 = float(obs[0])
+        drawdown = abs(float(obs[4]))
+        in_pos = bool(obs[6] > 0.5)
+        trailing_norm = float(obs[7])
+
+        # entry threshold w/ rebound adjustment and Gaussian noise
+        dyn_th = max(0.0, self.base_threshold - self.bounce_coef * drawdown)
+        dyn_th += self.rng.normal(0.0, self.noise_std)
+
+        # exit threshold (negative trailing_pct) with noise
+        exit_th = -self.trailing_pct + self.rng.normal(0.0, self.noise_std)
+
+        open_score = ret_5 - dyn_th if not in_pos else -np.inf
+        close_score = exit_th - trailing_norm if in_pos else -np.inf
+        hold_score = 0.0
+
+        scores = np.array([hold_score, open_score, close_score], dtype=np.float64)
+
+        trace: Dict[str, Any] = {
+            "ret_5": ret_5,
+            "drawdown": drawdown,
+            "dyn_threshold": dyn_th,
+            "exit_threshold": exit_th,
+            "trailing_norm": trailing_norm,
+            "in_pos": in_pos,
+            "scores": scores,
+        }
+        return scores, trace
+
+    # ------------------------------------------------------------------
+    def act(self, obs: np.ndarray, return_trace: bool = False):
+        """Sample an action according to softmaxed rule scores.
+
+        Parameters
+        ----------
+        obs : np.ndarray
+            Observation vector in the same order expected by
+            :class:`DeterministicPolicy`.
+        return_trace : bool, optional
+            Whether to return a trace dict along with the action.
+
+        Returns
+        -------
+        action : int
+            Chosen discrete action ``{0: hold, 1: open, 2: close}``.
+        probs : np.ndarray
+            Probability vector corresponding to the sampled action.
+        trace : Dict[str, Any], optional
+            Only returned when ``return_trace`` is ``True``.
+        """
+
+        scores, trace = self._score_actions(obs)
+
+        # softmax with temperature for stochasticity
+        shifted = (scores - np.max(scores)) / self.tau
+        exp_scores = np.exp(shifted)
+        probs = exp_scores / exp_scores.sum()
+
+        action = int(self.rng.choice(len(probs), p=probs))
+
+        trace.update({"probs": probs, "action": action})
+
+        if return_trace:
+            return action, probs, trace
+        return action, probs
+

--- a/tests/test_policy_router.py
+++ b/tests/test_policy_router.py
@@ -1,5 +1,5 @@
 from src.policies.router import get_policy
-from src.policies.value_based import TinyDQN
+from src.policies.value_based import ValueBasedPolicy
 from src.policies.deterministic import DeterministicPolicy
 from src.policies.stochastic import StochasticPolicy
 
@@ -9,4 +9,4 @@ def test_router():
     val = get_policy("dqn")
     assert isinstance(det, DeterministicPolicy)
     assert isinstance(sto, StochasticPolicy)
-    assert isinstance(val, TinyDQN)
+    assert isinstance(val, ValueBasedPolicy)


### PR DESCRIPTION
## Summary
- add modular PyTorch MLP and replay buffer
- implement DQN-style value-based policy with epsilon-greedy, target network, and save/load hooks
- expose buffer size and model path in default config and wire router and tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3dd8684a883288b07e7f8c6a249d1