### PR TITLE
feat: expose epsilon and entropy schedules for training

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -23,7 +23,8 @@ ppo:
   gamma: 0.99
   gae_lambda: 0.95
   clip_range: 0.2
-  ent_coef: 0.01
+  entropy_start: 0.01
+  entropy_end: 0.0
 dqn:
   learning_rate: 1.0e-3
   gamma: 0.99


### PR DESCRIPTION
## Summary
- support CLI overrides for DQN epsilon schedule and PPO entropy coefficient annealing
- save training hyperparameters alongside checkpoints and log them
- configure default PPO entropy schedule in default.yaml

## Testing
- `pip install -q pandas pyyaml`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ebc4e3ac83288f3b1fba2e6ed9ae