### PR TITLE
feat: add minimal DRL trainer and CLI wrapper

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,15 @@
+"""Thin wrapper around :mod:`src.training.train_drl`.
+
+This allows invoking the trainer via ``python scripts/train.py`` while the
+actual implementation resides in the package so it can also be executed with
+``python -m src.training.train_drl``.
+"""
+
+from __future__ import annotations
+
+from src.training.train_drl import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+


### PR DESCRIPTION
## Summary
- implement tiny numpy-based DQN with training loop, checkpoints and quick eval
- provide optional SB3 PPO helper
- add scripts/train.py wrapper for easy CLI access

## Testing
- `python -m src.training.train_drl --config configs/default.yaml --algo dqn --timesteps 5000`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee46a1e8832885c6dcaea7fb6406