### PR TITLE
feat: add backtest simulator metrics and reporting

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,15 @@
+"""Thin wrapper around :mod:`src.training.train_drl`.
+
+This allows invoking the trainer via ``python scripts/train.py`` while the
+actual implementation resides in the package so it can also be executed with
+``python -m src.training.train_drl``.
+"""
+
+from __future__ import annotations
+
+from src.training.train_drl import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/src/backtest/evaluate.py
+++ b/src/backtest/evaluate.py
@@ -3,9 +3,12 @@ import argparse, os
 import pandas as pd
 from .simulator import simulate
 from ..policies.router import get_policy
-from ..utils.data_io import load_table
+from ..utils.data_io import load_table, ensure_dir
 from ..utils.config import load_config
-from .metrics import sharpe, sortino, max_drawdown, turnover
+from .metrics import pnl, sharpe, sortino, max_drawdown, hit_ratio, turnover
+import json
+from datetime import datetime
+import matplotlib.pyplot as plt
 
 def main():
     ap = argparse.ArgumentParser()
@@ -28,16 +31,58 @@ def main():
         df = load_table(path)
 
     pol = get_policy(args.policy)
-    sim = simulate(df, pol, fees=cfg.get("fees",{}).get("taker",0.001), slippage=cfg.get("slippage",0.0005),
-                   min_notional_usd=cfg.get("min_notional_usd",10.0),
-                   tick_size=cfg.get("filters",{}).get("tickSize",0.01),
-                   step_size=cfg.get("filters",{}).get("stepSize",0.0001))
+    sim = simulate(
+        df,
+        pol,
+        fees=cfg.get("fees", {}).get("taker", 0.001),
+        slippage=cfg.get("slippage", 0.0005),
+        min_notional_usd=cfg.get("min_notional_usd", 10.0),
+        tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
+        step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
+    )
     equity = sim["equity"]
     trades = sim["trades"]
     rets = sim["returns"]
     equity_curve = (1.0 + rets).cumprod()
-    print(f"Equity final: {equity:.4f}")
-    print(f"Sharpe: {sharpe(rets):.3f} | Sortino: {sortino(rets):.3f} | MaxDD: {max_drawdown(equity_curve):.3%} | Turnover: {turnover(trades)}")
+
+    metrics = {
+        "pnl": pnl(rets),
+        "sharpe": sharpe(rets),
+        "sortino": sortino(rets),
+        "max_drawdown": max_drawdown(equity_curve),
+        "hit_ratio": hit_ratio(trades),
+        "turnover": turnover(trades),
+        "equity_final": equity,
+    }
+
+    print(
+        f"Equity final: {equity:.4f}\n"
+        f"PnL: {metrics['pnl']:.2%} | Sharpe: {metrics['sharpe']:.3f} | Sortino: {metrics['sortino']:.3f}\n"
+        f"MaxDD: {metrics['max_drawdown']:.3%} | HitRatio: {metrics['hit_ratio']:.2%} | Turnover: {metrics['turnover']}"
+    )
+
+    reports_root = paths.get("reports_dir", "reports")
+    run_id = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    run_dir = os.path.join(reports_root, run_id)
+    ensure_dir(run_dir)
+
+    # save metrics
+    with open(os.path.join(run_dir, "metrics.json"), "w") as f:
+        json.dump(metrics, f, indent=2)
+
+    # save trades
+    pd.DataFrame(trades).to_csv(os.path.join(run_dir, "trades.csv"), index=False)
+
+    # save equity curve
+    equity_curve.to_csv(os.path.join(run_dir, "equity.csv"), index_label="idx", header=["equity"])
+    plt.figure()
+    equity_curve.plot()
+    plt.title("Equity Curve")
+    plt.xlabel("trade")
+    plt.ylabel("equity")
+    plt.tight_layout()
+    plt.savefig(os.path.join(run_dir, "equity.png"))
+    plt.close()
 
 if __name__ == "__main__":
     main()

--- a/src/backtest/metrics.py
+++ b/src/backtest/metrics.py
@@ -1,29 +1,52 @@
 from __future__ import annotations
+
 import numpy as np
 import pandas as pd
+
+
+def pnl(returns: pd.Series) -> float:
+    """Total return over the period."""
+
+    if returns.empty:
+        return 0.0
+    return float((1.0 + returns).prod() - 1.0)
+
 
 def sharpe(returns: pd.Series, risk_free: float = 0.0, periods_per_year: int = 252) -> float:
     if returns.empty:
         return 0.0
-    excess = returns - risk_free/periods_per_year
+    excess = returns - risk_free / periods_per_year
     mu = excess.mean() * periods_per_year
     sigma = excess.std(ddof=1) * np.sqrt(periods_per_year)
     return float(mu / (sigma + 1e-12))
+
 
 def sortino(returns: pd.Series, risk_free: float = 0.0, periods_per_year: int = 252) -> float:
     if returns.empty:
         return 0.0
     downside = returns.clip(upper=0.0)
     dd = downside.std(ddof=1) * np.sqrt(periods_per_year)
-    mu = (returns - risk_free/periods_per_year).mean() * periods_per_year
+    mu = (returns - risk_free / periods_per_year).mean() * periods_per_year
     return float(mu / (dd + 1e-12))
+
 
 def max_drawdown(equity_curve: pd.Series) -> float:
     if equity_curve.empty:
         return 0.0
     roll_max = equity_curve.cummax()
-    drawdown = equity_curve/roll_max - 1.0
+    drawdown = equity_curve / roll_max - 1.0
     return float(drawdown.min())
+
+
+def hit_ratio(trades: list) -> float:
+    """Fraction of profitable trades."""
+
+    if not trades:
+        return 0.0
+    wins = sum(1 for t in trades if t.get("pnl", 0.0) > 0)
+    return float(wins / len(trades))
+
 
 def turnover(trades: list) -> float:
     return float(len(trades))
+

--- a/src/backtest/simulator.py
+++ b/src/backtest/simulator.py
@@ -1,34 +1,67 @@
 from __future__ import annotations
-from typing import Dict, Any, Tuple
+
+from typing import Any, Dict
+
 import numpy as np
 import pandas as pd
+
 from ..utils.risk import passes_min_notional, round_to_step, round_to_tick
 
-def simulate(price_df: pd.DataFrame, policy, fees: float=0.001, slippage: float=0.0005, min_notional_usd: float=10.0, tick_size: float=0.01, step_size: float=0.0001) -> Dict[str, Any]:
+
+def simulate(
+    price_df: pd.DataFrame,
+    policy,
+    fees: float = 0.001,
+    slippage: float = 0.0005,
+    min_notional_usd: float = 10.0,
+    tick_size: float = 0.01,
+    step_size: float = 0.0001,
+) -> Dict[str, Any]:
+    """Run a minimalistic trading simulation.
+
+    The simulator supports basic execution frictions such as commissions,
+    slippage, minimum notionals and exchange rounding rules.
+    """
+
     equity = 1.0
-    max_equity = equity
-    position = 0
+    position = 0  # 0 -> flat, 1 -> long
     entry = 0.0
-    trail = 0.0
-    trades = []
+    peak = 0.0
+    trades: list[Dict[str, Any]] = []
+
+    qty = round_to_step(1.0, step_size)
+
     for i in range(len(price_df)):
         row = price_df.iloc[i]
-        obs = np.array([1.0, 0.0, 0.0, 0.0, 0.0, float(position), trail/(row.close+1e-12)], dtype=np.float32)
-        action = policy.act(obs) if hasattr(policy, "act") else 0
         px = float(row.close)
+
+        trailing_norm = 0.0 if position == 0 else (px - peak) / (peak + 1e-12)
+        obs = np.array(
+            [0.02, 0.0, 0.0, 0.0, 0.0, 0.0, float(position), trailing_norm],
+            dtype=np.float32,
+        )
+        action = policy.act(obs) if hasattr(policy, "act") else 0
+
         if action == 1 and position == 0:
-            position = 1
-            entry = px * (1 + slippage)
+            exec_px = round_to_tick(px * (1 + slippage), tick_size)
+            if passes_min_notional(exec_px, qty, min_notional_usd):
+                entry = exec_px
+                peak = entry
+                position = 1
         elif action == 2 and position == 1:
-            exit_px = px * (1 - slippage)
-            pnl = (exit_px - entry)/entry - fees
-            equity *= (1.0 + pnl)
-            max_equity = max(max_equity, equity)
+            exit_px = round_to_tick(px * (1 - slippage), tick_size)
+            cost = entry * qty * (1 + fees)
+            proceeds = exit_px * qty * (1 - fees)
+            pnl = (proceeds - cost) / cost
+            equity *= 1.0 + pnl
             trades.append({"i": i, "entry": entry, "exit": exit_px, "pnl": pnl, "equity": equity})
             position = 0
             entry = 0.0
-            trail = 0.0
+            peak = 0.0
+
         if position == 1:
-            trail = max(trail, px - entry)
+            peak = max(peak, px)
+
     returns = pd.Series([t["pnl"] for t in trades]) if trades else pd.Series(dtype=float)
     return {"equity": equity, "trades": trades, "returns": returns}
+


### PR DESCRIPTION
## Summary
- implement trading simulator with fees, slippage, min notional and rounding
- provide performance metrics including PnL, Sharpe, Sortino, MaxDD, hit ratio and turnover
- export backtest reports (JSON/CSV) and equity curve plot under reports/

## Testing
- `python -m src.backtest.evaluate --config configs/default.yaml --policy deterministic`
- `PYTHONPATH=. pytest tests/test_policy_router.py -q`
- `PYTHONPATH=. pytest tests/test_data_loader_smoke.py tests/test_env_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee46a1e8832885c6dcaea7fb6406