### PR TITLE
Add Binance rounding utilities for risk checks

### DIFF
--- a/src/utils/risk.py
+++ b/src/utils/risk.py
@@ -1,15 +1,46 @@
 from __future__ import annotations
-from typing import Tuple
+
+from decimal import Decimal
+
 
 def round_to_step(x: float, step: float) -> float:
     if step <= 0:
         return x
     return round(x / step) * step
 
+
 def round_to_tick(price: float, tick: float) -> float:
     if tick <= 0:
         return price
     return round(price / tick) * tick
+
+
+def apply_price_tick(price: float, tick_size: float) -> float:
+    """Floor ``price`` to the nearest multiple of ``tick_size``.
+
+    Binance requires that order prices are multiples of the tick size. Any
+    excess precision is dropped rather than rounded to the nearest tick.
+    """
+    if tick_size <= 0:
+        return price
+    d_price = Decimal(str(price))
+    d_tick = Decimal(str(tick_size))
+    return float((d_price // d_tick) * d_tick)
+
+
+def apply_qty_step(qty: float, step_size: float) -> float:
+    """Floor ``qty`` to the nearest multiple of ``step_size``."""
+    if step_size <= 0:
+        return qty
+    d_qty = Decimal(str(qty))
+    d_step = Decimal(str(step_size))
+    return float((d_qty // d_step) * d_step)
+
+
+def respects_min_notional(price: float, qty: float, min_notional: float) -> bool:
+    """Return ``True`` if ``price * qty`` meets ``min_notional``."""
+    return price * qty >= min_notional
+
 
 def passes_min_notional(price: float, qty: float, min_notional_usd: float, quote_to_usd: float = 1.0) -> bool:
     return (price * qty * quote_to_usd) >= min_notional_usd

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.utils.risk import apply_price_tick, apply_qty_step, respects_min_notional
+
+
+def test_apply_price_tick():
+    assert apply_price_tick(100.123, 0.05) == pytest.approx(100.1)
+    assert apply_price_tick(100.149, 0.05) == pytest.approx(100.1)
+    assert apply_price_tick(100.15, 0.05) == pytest.approx(100.15)
+
+
+def test_apply_qty_step():
+    assert apply_qty_step(1.23456, 0.001) == pytest.approx(1.234)
+    assert apply_qty_step(0.98765, 0.01) == pytest.approx(0.98)
+
+
+def test_respects_min_notional():
+    assert respects_min_notional(100.0, 0.05, 5.0)
+    assert not respects_min_notional(100.0, 0.049, 5.0)


### PR DESCRIPTION
## Summary
- add helpers to floor prices and quantities to exchange tick sizes
- expose min-notional guard for simple checks
- test Binance-style rounding behaviour

## Testing
- `PYTHONPATH=. pytest tests/test_risk.py tests/test_risk_rounding.py -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3f5ed1f148328b5b00c3db0a57409