### PR TITLE
Add trade rate limits and Binance rounding utilities

### DIFF
--- a/src/utils/risk.py
+++ b/src/utils/risk.py
@@ -1,15 +1,46 @@
 from __future__ import annotations
-from typing import Tuple
+
+from decimal import Decimal
+
 
 def round_to_step(x: float, step: float) -> float:
     if step <= 0:
         return x
     return round(x / step) * step
 
+
 def round_to_tick(price: float, tick: float) -> float:
     if tick <= 0:
         return price
     return round(price / tick) * tick
+
+
+def apply_price_tick(price: float, tick_size: float) -> float:
+    """Floor ``price`` to the nearest multiple of ``tick_size``.
+
+    Binance requires that order prices are multiples of the tick size. Any
+    excess precision is dropped rather than rounded to the nearest tick.
+    """
+    if tick_size <= 0:
+        return price
+    d_price = Decimal(str(price))
+    d_tick = Decimal(str(tick_size))
+    return float((d_price // d_tick) * d_tick)
+
+
+def apply_qty_step(qty: float, step_size: float) -> float:
+    """Floor ``qty`` to the nearest multiple of ``step_size``."""
+    if step_size <= 0:
+        return qty
+    d_qty = Decimal(str(qty))
+    d_step = Decimal(str(step_size))
+    return float((d_qty // d_step) * d_step)
+
+
+def respects_min_notional(price: float, qty: float, min_notional: float) -> bool:
+    """Return ``True`` if ``price * qty`` meets ``min_notional``."""
+    return price * qty >= min_notional
+
 
 def passes_min_notional(price: float, qty: float, min_notional_usd: float, quote_to_usd: float = 1.0) -> bool:
     return (price * qty * quote_to_usd) >= min_notional_usd

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.utils.risk import apply_price_tick, apply_qty_step, respects_min_notional
+
+
+def test_apply_price_tick():
+    assert apply_price_tick(100.123, 0.05) == pytest.approx(100.1)
+    assert apply_price_tick(100.149, 0.05) == pytest.approx(100.1)
+    assert apply_price_tick(100.15, 0.05) == pytest.approx(100.15)
+
+
+def test_apply_qty_step():
+    assert apply_qty_step(1.23456, 0.001) == pytest.approx(1.234)
+    assert apply_qty_step(0.98765, 0.01) == pytest.approx(0.98)
+
+
+def test_respects_min_notional():
+    assert respects_min_notional(100.0, 0.05, 5.0)
+    assert not respects_min_notional(100.0, 0.049, 5.0)

--- a/tests/test_trade_limits.py
+++ b/tests/test_trade_limits.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import logging
+
+from src.env.trading_env import TradingEnv
+
+
+def _make_df(n: int = 5) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": [i * 60000 for i in range(n)],
+            "open": [100 + i for i in range(n)],
+            "high": [101 + i for i in range(n)],
+            "low": [99 + i for i in range(n)],
+            "close": [100 + i for i in range(n)],
+            "volume": [1 for _ in range(n)],
+        }
+    )
+
+
+def test_cooldown_blocks(caplog):
+    env = TradingEnv(_make_df(), trade_cooldown_seconds=120)
+    env.reset()
+    env.step(1)  # open trade at t=0
+    with caplog.at_level(logging.INFO):
+        _, _, _, _, info = env.step(2)  # attempt close at t=60s
+    assert info["reward_terms"]["turnover"] == 2.0
+    assert env.in_position  # still open due to block
+    assert "cooldown" in caplog.text.lower()
+
+
+def test_max_trades_window(caplog):
+    env = TradingEnv(
+        _make_df(),
+        max_trades_per_window=1,
+        trade_window_seconds=180,
+        trade_cooldown_seconds=0,
+    )
+    env.reset()
+    env.step(1)  # first trade
+    with caplog.at_level(logging.INFO):
+        _, _, _, _, info = env.step(2)  # second trade within window
+    assert info["reward_terms"]["turnover"] == 2.0
+    assert env.in_position
+    assert "max" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- add helpers to floor prices and quantities to exchange tick sizes
- expose min-notional guard for simple checks
- enforce rolling-window trade caps and second-based cooldowns with extra turnover penalty
- extend deterministic policy with matching throttling logic and tests

## Testing
- `PYTHONPATH=. pytest tests/test_trade_limits.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f5ed1f148328b5b00c3db0a57409