### PR TITLE
Add trade rate limits, Binance rounding, and configurable policy network

### DIFF
--- a/src/policies/nets.py
+++ b/src/policies/nets.py
@@ -1,18 +1,84 @@
 from __future__ import annotations
+
+"""Reusable neural network building blocks for policies."""
+
+from typing import Iterable, Sequence
+
+import torch
 import torch.nn as nn
 
+
+_ACTIVATIONS = {
+    "relu": nn.ReLU,
+    "tanh": nn.Tanh,
+    "sigmoid": nn.Sigmoid,
+    "gelu": nn.GELU,
+    "leaky_relu": nn.LeakyReLU,
+    "identity": nn.Identity,
+    None: nn.Identity,
+}
+
+
 class MLP(nn.Module):
-    """Simple multi-layer perceptron"""
-    def __init__(self, in_dim: int, hidden_sizes: tuple[int, ...], out_dim: int):
+    """Configurable multi-layer perceptron.
+
+    Parameters
+    ----------
+    in_dim:
+        Size of the input features.
+    hidden_sizes:
+        Iterable with the number of units for each hidden layer.
+    out_dim:
+        Size of the final output layer.
+    activation:
+        Either a single activation name applied to all hidden layers or a
+        sequence providing one activation per hidden layer. Supported names are
+        ``relu``, ``tanh``, ``sigmoid``, ``gelu`` and ``leaky_relu``.
+    dropout:
+        Optional dropout probability applied after each activation.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        hidden_sizes: Iterable[int],
+        out_dim: int,
+        *,
+        activation: str | Sequence[str] = "relu",
+        dropout: float | None = None,
+    ) -> None:
         super().__init__()
-        layers = []
+
+        hidden_sizes = list(hidden_sizes)
+        if isinstance(activation, str):
+            acts = [activation] * len(hidden_sizes)
+        else:
+            acts = list(activation)
+            if len(acts) != len(hidden_sizes):
+                raise ValueError("activation list must match hidden_sizes length")
+
+        layers: list[nn.Module] = []
         last = in_dim
-        for h in hidden_sizes:
-            layers.append(nn.Linear(last, h))
-            layers.append(nn.ReLU())
+        for h, act_name in zip(hidden_sizes, acts):
+            linear = nn.Linear(last, h)
+            nn.init.xavier_uniform_(linear.weight)
+            nn.init.zeros_(linear.bias)
+            layers.append(linear)
+            act_cls = _ACTIVATIONS.get(act_name.lower() if isinstance(act_name, str) else act_name)
+            if act_cls is None:
+                raise KeyError(f"Unknown activation '{act_name}'")
+            layers.append(act_cls())
+            if dropout:
+                layers.append(nn.Dropout(dropout))
             last = h
-        layers.append(nn.Linear(last, out_dim))
+
+        out = nn.Linear(last, out_dim)
+        nn.init.xavier_uniform_(out.weight)
+        nn.init.zeros_(out.bias)
+        layers.append(out)
+
         self.model = nn.Sequential(*layers)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.model(x)
+

--- a/src/utils/risk.py
+++ b/src/utils/risk.py
@@ -1,15 +1,46 @@
 from __future__ import annotations
-from typing import Tuple
+
+from decimal import Decimal
+
 
 def round_to_step(x: float, step: float) -> float:
     if step <= 0:
         return x
     return round(x / step) * step
 
+
 def round_to_tick(price: float, tick: float) -> float:
     if tick <= 0:
         return price
     return round(price / tick) * tick
+
+
+def apply_price_tick(price: float, tick_size: float) -> float:
+    """Floor ``price`` to the nearest multiple of ``tick_size``.
+
+    Binance requires that order prices are multiples of the tick size. Any
+    excess precision is dropped rather than rounded to the nearest tick.
+    """
+    if tick_size <= 0:
+        return price
+    d_price = Decimal(str(price))
+    d_tick = Decimal(str(tick_size))
+    return float((d_price // d_tick) * d_tick)
+
+
+def apply_qty_step(qty: float, step_size: float) -> float:
+    """Floor ``qty`` to the nearest multiple of ``step_size``."""
+    if step_size <= 0:
+        return qty
+    d_qty = Decimal(str(qty))
+    d_step = Decimal(str(step_size))
+    return float((d_qty // d_step) * d_step)
+
+
+def respects_min_notional(price: float, qty: float, min_notional: float) -> bool:
+    """Return ``True`` if ``price * qty`` meets ``min_notional``."""
+    return price * qty >= min_notional
+
 
 def passes_min_notional(price: float, qty: float, min_notional_usd: float, quote_to_usd: float = 1.0) -> bool:
     return (price * qty * quote_to_usd) >= min_notional_usd

--- a/tests/test_nets.py
+++ b/tests/test_nets.py
@@ -1,0 +1,30 @@
+import numpy as np
+import torch
+import pytest
+
+from src.policies.nets import MLP
+from src.policies.value_based import ValueBasedPolicy, DQNConfig
+
+
+def test_mlp_forward_and_dropout():
+    net = MLP(3, [4, 5], out_dim=2, activation="tanh", dropout=0.1)
+    x = torch.randn(7, 3)
+    y = net(x)
+    assert y.shape == (7, 2)
+    assert any(isinstance(m, torch.nn.Dropout) for m in net.model.modules())
+
+
+def test_value_policy_act_shape():
+    cfg = DQNConfig(hidden_sizes=(8,), activation="relu", dropout=None)
+    policy = ValueBasedPolicy(obs_dim=4, n_actions=3, config=cfg)
+    obs = np.zeros(4, dtype=np.float32)
+    action = policy.act(obs)
+    assert 0 <= action < 3
+
+
+def test_value_policy_act_raises_on_shape():
+    cfg = DQNConfig(hidden_sizes=(8,), activation="relu", dropout=None)
+    policy = ValueBasedPolicy(obs_dim=4, n_actions=3, config=cfg)
+    with pytest.raises(ValueError):
+        policy.act(np.zeros(5, dtype=np.float32))
+

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.utils.risk import apply_price_tick, apply_qty_step, respects_min_notional
+
+
+def test_apply_price_tick():
+    assert apply_price_tick(100.123, 0.05) == pytest.approx(100.1)
+    assert apply_price_tick(100.149, 0.05) == pytest.approx(100.1)
+    assert apply_price_tick(100.15, 0.05) == pytest.approx(100.15)
+
+
+def test_apply_qty_step():
+    assert apply_qty_step(1.23456, 0.001) == pytest.approx(1.234)
+    assert apply_qty_step(0.98765, 0.01) == pytest.approx(0.98)
+
+
+def test_respects_min_notional():
+    assert respects_min_notional(100.0, 0.05, 5.0)
+    assert not respects_min_notional(100.0, 0.049, 5.0)

--- a/tests/test_trade_limits.py
+++ b/tests/test_trade_limits.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import logging
+
+from src.env.trading_env import TradingEnv
+
+
+def _make_df(n: int = 5) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": [i * 60000 for i in range(n)],
+            "open": [100 + i for i in range(n)],
+            "high": [101 + i for i in range(n)],
+            "low": [99 + i for i in range(n)],
+            "close": [100 + i for i in range(n)],
+            "volume": [1 for _ in range(n)],
+        }
+    )
+
+
+def test_cooldown_blocks(caplog):
+    env = TradingEnv(_make_df(), trade_cooldown_seconds=120)
+    env.reset()
+    env.step(1)  # open trade at t=0
+    with caplog.at_level(logging.INFO):
+        _, _, _, _, info = env.step(2)  # attempt close at t=60s
+    assert info["reward_terms"]["turnover"] == 2.0
+    assert env.in_position  # still open due to block
+    assert "cooldown" in caplog.text.lower()
+
+
+def test_max_trades_window(caplog):
+    env = TradingEnv(
+        _make_df(),
+        max_trades_per_window=1,
+        trade_window_seconds=180,
+        trade_cooldown_seconds=0,
+    )
+    env.reset()
+    env.step(1)  # first trade
+    with caplog.at_level(logging.INFO):
+        _, _, _, _, info = env.step(2)  # second trade within window
+    assert info["reward_terms"]["turnover"] == 2.0
+    assert env.in_position
+    assert "max" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- expose flexible MLP builder supporting custom activations, optional dropout, and Xavier initialization
- plug the new network into the value-based policy with shape validation on inference
- extend training script with PyTorch DQN path and tests covering network usage

## Testing
- `python -m pytest tests/test_nets.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3f5ed1f148328b5b00c3db0a57409