### PR TITLE
fix: replace deprecated utcnow

### DIFF
--- a/src/backtest/evaluate.py
+++ b/src/backtest/evaluate.py
@@ -7,7 +7,7 @@ from ..utils.data_io import load_table, ensure_dir
 from ..utils.config import load_config
 from .metrics import pnl, sharpe, sortino, max_drawdown, hit_ratio, turnover
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 import matplotlib.pyplot as plt
 
 def main():
@@ -62,7 +62,7 @@ def main():
     )
 
     reports_root = paths.get("reports_dir", "reports")
-    run_id = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     run_dir = os.path.join(reports_root, run_id)
     ensure_dir(run_dir)
 

--- a/src/env/trading_env.py
+++ b/src/env/trading_env.py
@@ -16,27 +16,48 @@ import pandas as pd
 import yaml
 import logging
 
+try:  # pragma: no cover - optional gym dependency
+    import gymnasium as gym
+    from gymnasium import spaces
+except Exception:  # pragma: no cover - optional gym dependency
+    try:
+        import gym
+        from gym import spaces  # type: ignore[no-redef]
+    except Exception:  # pragma: no cover - fallback when gym is unavailable
+        gym = None  # type: ignore[assignment]
+
+        @dataclass
+        class _Space:
+            """Simple stand-in for a gym ``Space`` object."""
+
+            shape: Tuple[int, ...]
+            dtype: Any = np.float32
+
+        @dataclass
+        class _Discrete:
+            """Minimal discrete space (``n`` possible integer actions)."""
+
+            n: int
+            dtype: Any = np.int64
+
+        def _box(*, low: Any, high: Any, shape: Tuple[int, ...], dtype: Any = np.float32) -> _Space:
+            return _Space(shape, dtype)
+
+        def _discrete(n: int, dtype: Any = np.int64) -> _Discrete:
+            return _Discrete(n, dtype)
+
+        class _Spaces:  # minimal module-like container
+            Box = staticmethod(_box)
+            Discrete = staticmethod(_discrete)
+
+        spaces = _Spaces()  # type: ignore[assignment]
+
 from ..utils.orderbook import compute_walls, distancia_a_muralla
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class _Space:
-    """Simple stand-in for a gym ``Space`` object."""
-
-    shape: Tuple[int, ...]
-    dtype: Any = np.float32
-
-@dataclass
-class _Discrete:
-    """Minimal discrete space (``n`` possible integer actions)."""
-
-    n: int
-    dtype: Any = np.int64
-
-
-class TradingEnv:
+class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
     def __init__(
         self,
         df: pd.DataFrame,
@@ -66,9 +87,11 @@ class TradingEnv:
         self._feature_histories: List[List[float]] = [[] for _ in range(8)]
 
         # observation space: 8 engineered features, float32
-        self.observation_space = _Space((8,), np.float32)
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(8,), dtype=np.float32
+        )
         # discrete action space: 0=hold, 1=open_long, 2=close
-        self.action_space = _Discrete(3, np.int64)
+        self.action_space = spaces.Discrete(3)
         # in the future this could include a continuous component (0..1)
         # to express position sizing alongside the discrete action
         # config ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.now(timezone.utc)` in backtest evaluation
- make `TradingEnv` compatible with Gym/Gymnasium or no-gym fallback
- instantiate discrete action space without `dtype` to match Gym API

## Testing
- `python -m pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not connect to proxy, 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a478b4a3648328901b77cb28e1ca55