### PR TITLE
Default to Binance with testnet toggle and auto symbol discovery

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "get_exchange",
     "fetch_ohlcv",
     "save_history",
+    "discover_symbols",
 ]
 
 from .ccxt_loader import (  # noqa: E402
@@ -13,4 +14,5 @@ from .ccxt_loader import (  # noqa: E402
     fetch_ohlcv,
     save_history,
 )
+from .symbol_discovery import discover_symbols
 

--- a/src/data/symbol_discovery.py
+++ b/src/data/symbol_discovery.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import List
+
+STABLES = {
+    "USDT",
+    "USDC",
+    "BUSD",
+    "DAI",
+    "TUSD",
+    "PAX",
+    "EUR",
+    "GBP",
+    "JPY",
+    "RUB",
+}
+
+EXOTIC_SUFFIXES = ("UP", "DOWN", "BULL", "BEAR")
+
+
+def discover_symbols(exchange, quote: str = "USDT", top_n: int = 20) -> List[str]:
+    """Return the most active symbols for *exchange* sorted by quote volume.
+
+    Parameters
+    ----------
+    exchange:
+        A ccxt exchange instance providing :meth:`fetch_tickers`.
+    quote:
+        The quote currency to filter for, defaults to ``"USDT"``.
+    top_n:
+        Maximum number of symbols to return.
+
+    Returns
+    -------
+    list[str]
+        Symbols like ``"BTC/USDT"`` ordered by descending ``quoteVolume``.
+    """
+
+    try:  # pragma: no cover - network/ccxt quirks
+        tickers = exchange.fetch_tickers()
+    except Exception as exc:  # pragma: no cover - network/ccxt quirks
+        raise RuntimeError("failed to fetch tickers for discovery") from exc
+
+    ranked = []
+    for symbol, info in tickers.items():
+        if not symbol.endswith(f"/{quote}"):
+            continue
+        base, _ = symbol.split("/")
+        if base in STABLES:
+            continue
+        if any(base.endswith(suf) for suf in EXOTIC_SUFFIXES):
+            continue
+        qv = float(info.get("quoteVolume") or 0.0)
+        ranked.append((qv, symbol))
+
+    ranked.sort(reverse=True)
+    return [sym for _, sym in ranked[:top_n]]

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -3,8 +3,9 @@ from datetime import datetime
 import streamlit as st
 
 from src.utils.config import load_config
-from src.utils.data_io import load_table
+from src.utils.paths import ensure_dirs_exist, get_raw_dir
 from src.data.ccxt_loader import get_exchange, fetch_ohlcv, simulate_1s_from_1m, save_history
+from src.data.symbol_discovery import discover_symbols
 
 CONFIG_PATH = st.session_state.get("config_path", "configs/default.yaml")
 
@@ -19,28 +20,40 @@ with st.sidebar:
     # Cargar YAML
     try:
         cfg = load_config(CONFIG_PATH)
+        ensure_dirs_exist(cfg)
     except Exception as e:
         st.error(f"No se pudo cargar {CONFIG_PATH}: {e}")
         cfg = {}
 
-    paths = cfg.get("paths", {})
-    logs_dir = paths.get("logs_dir", "logs")
-    checkpoints_dir = paths.get("checkpoints_dir", "checkpoints")
-    raw_dir = paths.get("raw_dir", "data/raw")
-    reports_dir = paths.get("reports_dir", "reports")
+    paths_cfg = cfg.get("paths", {})
+    raw_dir = get_raw_dir(cfg)
+    use_testnet_default = bool(cfg.get("binance_use_testnet", False))
+    mode = st.radio("Modo", ["Mainnet", "Testnet"], index=1 if use_testnet_default else 0)
+    use_testnet = mode == "Testnet"
+    os.environ["BINANCE_USE_TESTNET"] = "true" if use_testnet else "false"
 
-    st.caption("Rutas")
-    colp1, colp2 = st.columns(2)
-    with colp1:
-        raw_dir = st.text_input("Data raw dir", value=raw_dir, key="raw_dir")
-        logs_dir = st.text_input("Logs dir", value=logs_dir, key="logs_dir")
-    with colp2:
-        checkpoints_dir = st.text_input("Checkpoints dir", value=checkpoints_dir, key="ckpt_dir")
-        reports_dir = st.text_input("Reports dir", value=reports_dir, key="reports_dir")
+    st.caption("Símbolos sugeridos (auto)")
+    refresh_syms = st.button("Actualizar", key="refresh_syms")
+    if "symbol_checks" not in st.session_state or refresh_syms:
+        try:
+            ex = get_exchange(use_testnet=use_testnet)
+            suggested = discover_symbols(ex, top_n=20)
+        except Exception as e:
+            st.warning(f"Descubrimiento falló: {e}")
+            suggested = cfg.get("symbols") or ["BTC/USDT"]
+        checks = st.session_state.get("symbol_checks", {})
+        for s in suggested:
+            checks.setdefault(s, True)
+        st.session_state["symbol_checks"] = checks
+    checks = st.session_state.get("symbol_checks", {})
+    for sym in sorted(checks):
+        checks[sym] = st.checkbox(sym, value=checks[sym], key=f"sym_{sym}")
+    manual = st.text_input("Añadir manualmente", key="manual_sym").upper().strip()
+    if manual and manual not in checks:
+        checks[manual] = True
+    selected_symbols = [s for s, v in checks.items() if v]
+    cfg["symbols"] = selected_symbols
 
-    st.caption("Exchange")
-    ex_name = st.text_input("Exchange (ccxt)", value=cfg.get("exchange","binance"), key="exchange_ccxt")
-    symbols = st.text_input("Símbolos (espacio-separado)", value=" ".join(cfg.get("symbols") or ["BTC/USDT"]), key="symbols_space")
     timeframe = st.selectbox("Timeframe", ["1s","1m","3m","5m","15m"], index=1)
 
     fees_taker = st.number_input("Fee taker", value=float(cfg.get("fees",{}).get("taker",0.001)), step=0.0001, format="%.6f")
@@ -83,10 +96,11 @@ with st.sidebar:
     if st.button("💾 Guardar config YAML"):
         import yaml
         new_cfg = {
-            "exchange": ex_name,
-            "symbols": symbols.split(),
+            "exchange": "binance",
+            "binance_use_testnet": use_testnet,
+            "symbols": selected_symbols,
             "timeframe": timeframe,
-            "fees": {"taker": fees_taker, "maker": cfg.get("fees",{}).get("maker", fees_taker)},
+            "fees": {"taker": fees_taker, "maker": cfg.get("fees", {}).get("maker", fees_taker)},
             "slippage": slippage,
             "min_notional_usd": min_notional,
             "filters": {"tickSize": tick_size, "stepSize": step_size},
@@ -101,9 +115,7 @@ with st.sidebar:
                 "epsilon_end": dqn_eps_e, "epsilon_decay_steps": int(dqn_eps_d)
             },
             "reward_weights": {"pnl": w_pnl, "turnover_penalty": w_turn, "drawdown_penalty": w_dd, "volatility_penalty": w_vol},
-            "paths": {
-                "raw_dir": raw_dir, "logs_dir": logs_dir, "reports_dir": reports_dir, "checkpoints_dir": checkpoints_dir
-            },
+            "paths": paths_cfg,
         }
         os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
         with open(CONFIG_PATH, "w", encoding="utf-8") as f:
@@ -111,18 +123,15 @@ with st.sidebar:
         st.success(f"Guardado {CONFIG_PATH}")
 
 st.subheader("📥 Datos")
-col1, col2, col3 = st.columns(3)
+col1, col2 = st.columns(2)
 with col1:
-    ex_name_run = st.text_input("Exchange para descarga", value=ex_name, key="exchange_dl")
-with col2:
     dl_timeframe = st.selectbox("Timeframe descarga", ["1s","1m","3m","5m","15m"], index=1, key="dl_tf")
-with col3:
+with col2:
     since = st.text_input("Desde (ISO UTC, ej. 2024-01-01)", value="", key="since_iso")
-
-symbols_run = st.text_input("Símbolos a descargar", value=symbols, key="symbols_dl")
+st.write("Seleccionados: " + ", ".join(selected_symbols))
 if st.button("⬇️ Descargar histórico"):
     try:
-        ex = get_exchange(ex_name_run)
+        ex = get_exchange(use_testnet=use_testnet)
         from datetime import datetime, timezone
         since_ms = None
         if since:
@@ -131,13 +140,13 @@ if st.button("⬇️ Descargar histórico"):
                 since_ms = int(dt.timestamp()*1000)
             except Exception:
                 since_ms = None
-        for sym in symbols_run.split():
+        for sym in selected_symbols:
             df = fetch_ohlcv(ex, sym, timeframe=dl_timeframe, since=since_ms)
             if dl_timeframe == "1s" and df.empty:
                 st.warning(f"1s no disponible en {sym}; simulando desde 1m")
                 df_1m = fetch_ohlcv(ex, sym, timeframe="1m", since=since_ms)
                 df = simulate_1s_from_1m(df_1m)
-            path = save_history(df, raw_dir, ex_name_run, sym, dl_timeframe)
+            path = save_history(df, str(raw_dir), "binance", sym, dl_timeframe)
             st.success(f"Guardado: {path}")
     except Exception as e:
         st.error(f"Error en descarga: {e}")
@@ -148,12 +157,14 @@ with colt1:
     algo_run = st.selectbox("Algoritmo", ["ppo","dqn"], index=0 if algo=="ppo" else 1)
     timesteps = st.number_input("Timesteps", value=20000, step=1000)
 with colt2:
-    data_override = st.text_input("Ruta datos (opcional)", value="", key="train_data_override")
+    st.empty()
 
 if st.button("🚀 Entrenar"):
-    cmd = ["python", "-m", "src.training.train_drl", "--config", CONFIG_PATH, "--algo", algo_run, "--timesteps", str(int(timesteps))]
-    if data_override:
-        cmd.extend(["--data", data_override])
+    import tempfile, yaml
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg, tmp, sort_keys=False, allow_unicode=True)
+        cfg_path = tmp.name
+    cmd = ["python", "-m", "src.training.train_drl", "--config", cfg_path, "--algo", algo_run, "--timesteps", str(int(timesteps))]
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)
@@ -168,12 +179,14 @@ colb1, colb2 = st.columns(2)
 with colb1:
     policy = st.selectbox("Política", ["deterministic","stochastic","dqn"])
 with colb2:
-    data_eval = st.text_input("Ruta datos (opcional)", value="", key="eval_data_override")
+    st.empty()
 
 if st.button("📈 Evaluar"):
-    cmd = ["python", "-m", "src.backtest.evaluate", "--config", CONFIG_PATH, "--policy", policy]
-    if data_eval:
-        cmd.extend(["--data", data_eval])
+    import tempfile, yaml
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg, tmp, sort_keys=False, allow_unicode=True)
+        cfg_path = tmp.name
+    cmd = ["python", "-m", "src.backtest.evaluate", "--config", cfg_path, "--policy", policy]
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -22,6 +22,10 @@ def load_config(path: str, overrides: Dict[str, Any] | None = None) -> Dict[str,
         if v is not None:
             cfg.setdefault("env", {})[k] = v
 
+    use_testnet = os.getenv("BINANCE_USE_TESTNET")
+    if use_testnet is not None:
+        cfg["binance_use_testnet"] = use_testnet.lower() in ("1", "true", "yes")
+
     # Apply explicit overrides (e.g., CLI flags)
     if overrides:
         for k, v in overrides.items():

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Helper utilities for resolving common project directories."""
+
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _paths(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the ``paths`` section from the config or an empty mapping."""
+    return cfg.get("paths", {}) if isinstance(cfg, Mapping) else {}
+
+
+def get_raw_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory containing raw market data."""
+    return Path(_paths(cfg).get("raw_dir", "data/raw"))
+
+
+def get_reports_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory where evaluation reports are stored."""
+    return Path(_paths(cfg).get("reports_dir", "reports"))
+
+
+def get_checkpoints_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory for model checkpoints."""
+    return Path(_paths(cfg).get("checkpoints_dir", "checkpoints"))
+
+
+def ensure_dirs_exist(cfg: Mapping[str, Any]) -> None:
+    """Create common project directories if they do not already exist."""
+    for directory in [get_raw_dir(cfg), get_reports_dir(cfg), get_checkpoints_dir(cfg)]:
+        directory.mkdir(parents=True, exist_ok=True)

--- a/tests/test_binance_testnet.py
+++ b/tests/test_binance_testnet.py
@@ -1,0 +1,18 @@
+import os
+from src.data.ccxt_loader import get_exchange
+
+
+def _api_url(exchange):
+    api = exchange.urls["api"]
+    if isinstance(api, dict):
+        return api.get("public", "")
+    return api
+
+
+def test_get_exchange_respects_env(monkeypatch):
+    monkeypatch.setenv("BINANCE_USE_TESTNET", "true")
+    ex = get_exchange()
+    assert "testnet" in _api_url(ex).lower()
+    monkeypatch.setenv("BINANCE_USE_TESTNET", "false")
+    ex2 = get_exchange()
+    assert "testnet" not in _api_url(ex2).lower()

--- a/tests/test_evaluate_reports.py
+++ b/tests/test_evaluate_reports.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def test_evaluate_creates_report(tmp_path):
+    cfg = yaml.safe_load(Path('configs/default.yaml').read_text())
+    cfg_paths = cfg.setdefault('paths', {})
+    cfg_paths['raw_dir'] = str(tmp_path / 'raw')
+    cfg_paths['reports_dir'] = str(tmp_path / 'reports')
+    cfg_paths['checkpoints_dir'] = str(tmp_path / 'checkpoints')
+    cfg_path = tmp_path / 'cfg.yaml'
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    data_dir = Path(cfg_paths['raw_dir']) / 'binance' / 'BTC-USDT'
+    data_dir.mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            'open': [100, 103, 101, 101],
+            'high': [100, 103, 101, 101],
+            'low': [100, 103, 101, 101],
+            'close': [100, 103, 101, 101],
+        }
+    )
+    df.to_csv(data_dir / '1m.csv', index=False)
+
+    env = os.environ.copy()
+    env['MPLBACKEND'] = 'Agg'
+    subprocess.run(
+        ['python', '-m', 'src.backtest.evaluate', '--config', str(cfg_path), '--policy', 'deterministic'],
+        check=True,
+        env=env,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+    reports_dir = Path(cfg_paths['reports_dir'])
+    runs = list(reports_dir.iterdir())
+    assert len(runs) == 1
+    run_dir = runs[0]
+    assert (run_dir / 'metrics.json').is_file()
+    assert (run_dir / 'trades.csv').is_file()
+    assert (run_dir / 'equity.csv').is_file()

--- a/tests/test_symbol_discovery.py
+++ b/tests/test_symbol_discovery.py
@@ -1,0 +1,32 @@
+from src.data.symbol_discovery import discover_symbols
+
+
+class DummyEx:
+    def fetch_tickers(self):
+        return {
+            "BTC/USDT": {"quoteVolume": 100000},
+            "ETH/USDT": {"quoteVolume": 90000},
+            "USDC/USDT": {"quoteVolume": 80000},
+            "LTC/USDT": {"quoteVolume": 50000},
+            "BTC/USDC": {"quoteVolume": 120},
+            "XRP/USDT": {"quoteVolume": 70000},
+            "ETHUP/USDT": {"quoteVolume": 60000},
+            "BNB/USDT": {"quoteVolume": 65000},
+            "FOO/USDT": {"quoteVolume": 10},
+        }
+
+
+def test_discover_symbols_filters_and_sorts():
+    ex = DummyEx()
+    syms = discover_symbols(ex, top_n=5)
+    assert syms[0] == "BTC/USDT"
+    assert "USDC/USDT" not in syms  # filtered stablecoin
+    assert "ETHUP/USDT" not in syms  # filtered exotic suffix
+    assert len(syms) == 5
+    assert syms == [
+        "BTC/USDT",
+        "ETH/USDT",
+        "XRP/USDT",
+        "BNB/USDT",
+        "LTC/USDT",
+    ]


### PR DESCRIPTION
## Summary
- add `discover_symbols` helper to rank Binance markets by quote volume
- streamlit UI suggests top pairs with refresh & manual add and uses the selection for downloads and training
- training/evaluation run with a temporary config reflecting chosen symbols

## Testing
- `pytest tests/test_symbol_discovery.py -q`
- `pytest tests/test_binance_testnet.py -q`
- `pytest tests/test_evaluate_reports.py::test_evaluate_creates_report -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68a485669a8c83289eb58f5ae0543fca