### PR TITLE
Default to Binance with testnet toggle and auto symbol discovery

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "get_exchange",
     "fetch_ohlcv",
     "save_history",
+    "discover_symbols",
 ]
 
 from .ccxt_loader import (  # noqa: E402
@@ -13,4 +14,5 @@ from .ccxt_loader import (  # noqa: E402
     fetch_ohlcv,
     save_history,
 )
+from .symbol_discovery import discover_symbols
 

--- a/src/data/ccxt_loader.py
+++ b/src/data/ccxt_loader.py
@@ -8,6 +8,7 @@ lightweight to avoid heavy dependencies during testing.
 from __future__ import annotations
 
 import os
+import logging
 from typing import Any, Optional
 
 import pandas as pd
@@ -18,6 +19,9 @@ __all__ = [
     "fetch_ohlcv",
     "save_history",
 ]
+
+
+logger = logging.getLogger(__name__)
 
 
 def simulate_1s_from_1m(df_1m: pd.DataFrame) -> pd.DataFrame:
@@ -57,12 +61,12 @@ def simulate_1s_from_1m(df_1m: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
 
 
-def get_exchange(name: str):
-    """Instantiate a ``ccxt`` exchange by *name*.
+def get_exchange(name: str | None = None, *, use_testnet: bool | None = None):
+    """Return a ``ccxt`` Binance client.
 
-    The library is imported lazily so environments without ``ccxt`` can still
-    import this module for testing purposes.  An informative ``ImportError`` is
-    raised if the dependency is missing when the function is used.
+    ``name`` is kept for backwards compatibility and must be ``\"binance\"`` if
+    provided.  Testnet mode is enabled when ``use_testnet`` is ``True`` or when
+    the ``BINANCE_USE_TESTNET`` environment variable is truthy.
     """
 
     try:  # pragma: no cover - exercised only when ccxt is available
@@ -70,15 +74,22 @@ def get_exchange(name: str):
     except Exception as exc:  # pragma: no cover - missing optional dep
         raise ImportError("ccxt is required to create exchange clients") from exc
 
-    try:
-        cls = getattr(ccxt, name)
-    except AttributeError as exc:
-        raise ValueError(f"unknown exchange: {name}") from exc
+    if name and name.lower() != "binance":
+        raise ValueError("only binance exchange is supported")
 
-    ex = cls()
-    try:
+    if use_testnet is None:
+        use_testnet = os.getenv("BINANCE_USE_TESTNET", "").lower() in ("1", "true", "yes")
+
+    ex = ccxt.binance({"enableRateLimit": True})
+    if use_testnet:  # pragma: no cover - network/ccxt quirks
+        try:
+            ex.set_sandbox_mode(True)
+        except Exception:
+            ex.urls["api"] = ex.urls.get("test", ex.urls.get("api"))
+
+    try:  # pragma: no cover - network/ccxt quirks
         ex.load_markets()
-    except Exception:  # pragma: no cover - network/ccxt quirks
+    except Exception:
         pass
     return ex
 
@@ -86,14 +97,35 @@ def get_exchange(name: str):
 def fetch_ohlcv(
     exchange: Any,
     symbol: str,
-    timeframe: str = "1m",
+    timeframe: Optional[str] = None,
     since: Optional[int] = None,
     limit: int = 1000,
 ) -> pd.DataFrame:
-    """Fetch OHLCV data from *exchange* and return a DataFrame."""
+    """Fetch OHLCV data from *exchange* and return a DataFrame.
 
-    data = exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)
-    return pd.DataFrame(data, columns=["ts", "open", "high", "low", "close", "volume"])
+    When *timeframe* is ``None`` the function attempts to pick the smallest
+    available timeframe from ``exchange.timeframes`` following the order
+    ``["1s","3s","5s","15s","30s","1m","3m","5m"]``.  The chosen
+    timeframe is stored in ``df.attrs['timeframe']`` and logged via the module
+    logger.
+    """
+
+    tf = timeframe
+    if tf is None:
+        candidates = ["1s", "3s", "5s", "15s", "30s", "1m", "3m", "5m"]
+        available = getattr(exchange, "timeframes", {}) or {}
+        for cand in candidates:
+            if cand in available:
+                tf = cand
+                break
+        if tf is None:  # pragma: no cover - unlikely for Binance
+            raise ValueError("no supported timeframe found")
+        logger.info("selected_timeframe=%s", tf)
+
+    data = exchange.fetch_ohlcv(symbol, timeframe=tf, since=since, limit=limit)
+    df = pd.DataFrame(data, columns=["ts", "open", "high", "low", "close", "volume"])
+    df.attrs["timeframe"] = tf
+    return df
 
 
 def save_history(

--- a/src/data/symbol_discovery.py
+++ b/src/data/symbol_discovery.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import List
+
+STABLES = {
+    "USDT",
+    "USDC",
+    "BUSD",
+    "DAI",
+    "TUSD",
+    "PAX",
+    "EUR",
+    "GBP",
+    "JPY",
+    "RUB",
+}
+
+EXOTIC_SUFFIXES = ("UP", "DOWN", "BULL", "BEAR")
+
+
+def discover_symbols(exchange, quote: str = "USDT", top_n: int = 20) -> List[str]:
+    """Return the most active symbols for *exchange* sorted by quote volume.
+
+    Parameters
+    ----------
+    exchange:
+        A ccxt exchange instance providing :meth:`fetch_tickers`.
+    quote:
+        The quote currency to filter for, defaults to ``"USDT"``.
+    top_n:
+        Maximum number of symbols to return.
+
+    Returns
+    -------
+    list[str]
+        Symbols like ``"BTC/USDT"`` ordered by descending ``quoteVolume``.
+    """
+
+    try:  # pragma: no cover - network/ccxt quirks
+        tickers = exchange.fetch_tickers()
+    except Exception as exc:  # pragma: no cover - network/ccxt quirks
+        raise RuntimeError("failed to fetch tickers for discovery") from exc
+
+    ranked = []
+    for symbol, info in tickers.items():
+        if not symbol.endswith(f"/{quote}"):
+            continue
+        base, _ = symbol.split("/")
+        if base in STABLES:
+            continue
+        if any(base.endswith(suf) for suf in EXOTIC_SUFFIXES):
+            continue
+        qv = float(info.get("quoteVolume") or 0.0)
+        ranked.append((qv, symbol))
+
+    ranked.sort(reverse=True)
+    return [sym for _, sym in ranked[:top_n]]

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -3,8 +3,9 @@ from datetime import datetime
 import streamlit as st
 
 from src.utils.config import load_config
-from src.utils.data_io import load_table
-from src.data.ccxt_loader import get_exchange, fetch_ohlcv, simulate_1s_from_1m, save_history
+from src.utils.paths import ensure_dirs_exist, get_raw_dir
+from src.data.ccxt_loader import get_exchange, fetch_ohlcv, save_history
+from src.data.symbol_discovery import discover_symbols
 
 CONFIG_PATH = st.session_state.get("config_path", "configs/default.yaml")
 
@@ -19,29 +20,40 @@ with st.sidebar:
     # Cargar YAML
     try:
         cfg = load_config(CONFIG_PATH)
+        ensure_dirs_exist(cfg)
     except Exception as e:
         st.error(f"No se pudo cargar {CONFIG_PATH}: {e}")
         cfg = {}
 
-    paths = cfg.get("paths", {})
-    logs_dir = paths.get("logs_dir", "logs")
-    checkpoints_dir = paths.get("checkpoints_dir", "checkpoints")
-    raw_dir = paths.get("raw_dir", "data/raw")
-    reports_dir = paths.get("reports_dir", "reports")
+    paths_cfg = cfg.get("paths", {})
+    raw_dir = get_raw_dir(cfg)
+    use_testnet_default = bool(cfg.get("binance_use_testnet", False))
+    mode = st.radio("Modo", ["Mainnet", "Testnet"], index=1 if use_testnet_default else 0)
+    use_testnet = mode == "Testnet"
+    os.environ["BINANCE_USE_TESTNET"] = "true" if use_testnet else "false"
 
-    st.caption("Rutas")
-    colp1, colp2 = st.columns(2)
-    with colp1:
-        raw_dir = st.text_input("Data raw dir", value=raw_dir, key="raw_dir")
-        logs_dir = st.text_input("Logs dir", value=logs_dir, key="logs_dir")
-    with colp2:
-        checkpoints_dir = st.text_input("Checkpoints dir", value=checkpoints_dir, key="ckpt_dir")
-        reports_dir = st.text_input("Reports dir", value=reports_dir, key="reports_dir")
+    st.caption("Símbolos sugeridos (auto)")
+    refresh_syms = st.button("Actualizar", key="refresh_syms")
+    if "symbol_checks" not in st.session_state or refresh_syms:
+        try:
+            ex = get_exchange(use_testnet=use_testnet)
+            suggested = discover_symbols(ex, top_n=20)
+        except Exception as e:
+            st.warning(f"Descubrimiento falló: {e}")
+            suggested = cfg.get("symbols") or ["BTC/USDT"]
+        checks = st.session_state.get("symbol_checks", {})
+        for s in suggested:
+            checks.setdefault(s, True)
+        st.session_state["symbol_checks"] = checks
+    checks = st.session_state.get("symbol_checks", {})
+    for sym in sorted(checks):
+        checks[sym] = st.checkbox(sym, value=checks[sym], key=f"sym_{sym}")
+    manual = st.text_input("Añadir manualmente", key="manual_sym").upper().strip()
+    if manual and manual not in checks:
+        checks[manual] = True
+    selected_symbols = [s for s, v in checks.items() if v]
+    cfg["symbols"] = selected_symbols
 
-    st.caption("Exchange")
-    ex_name = st.text_input("Exchange (ccxt)", value=cfg.get("exchange","binance"), key="exchange_ccxt")
-    symbols = st.text_input("Símbolos (espacio-separado)", value=" ".join(cfg.get("symbols") or ["BTC/USDT"]), key="symbols_space")
-    timeframe = st.selectbox("Timeframe", ["1s","1m","3m","5m","15m"], index=1)
 
     fees_taker = st.number_input("Fee taker", value=float(cfg.get("fees",{}).get("taker",0.001)), step=0.0001, format="%.6f")
     slippage = st.number_input("Slippage", value=float(cfg.get("slippage",0.0005)), step=0.0001, format="%.6f")
@@ -83,10 +95,11 @@ with st.sidebar:
     if st.button("💾 Guardar config YAML"):
         import yaml
         new_cfg = {
-            "exchange": ex_name,
-            "symbols": symbols.split(),
-            "timeframe": timeframe,
-            "fees": {"taker": fees_taker, "maker": cfg.get("fees",{}).get("maker", fees_taker)},
+            "exchange": "binance",
+            "binance_use_testnet": use_testnet,
+            "symbols": selected_symbols,
+            "timeframe": cfg.get("timeframe", "1m"),
+            "fees": {"taker": fees_taker, "maker": cfg.get("fees", {}).get("maker", fees_taker)},
             "slippage": slippage,
             "min_notional_usd": min_notional,
             "filters": {"tickSize": tick_size, "stepSize": step_size},
@@ -101,9 +114,7 @@ with st.sidebar:
                 "epsilon_end": dqn_eps_e, "epsilon_decay_steps": int(dqn_eps_d)
             },
             "reward_weights": {"pnl": w_pnl, "turnover_penalty": w_turn, "drawdown_penalty": w_dd, "volatility_penalty": w_vol},
-            "paths": {
-                "raw_dir": raw_dir, "logs_dir": logs_dir, "reports_dir": reports_dir, "checkpoints_dir": checkpoints_dir
-            },
+            "paths": paths_cfg,
         }
         os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
         with open(CONFIG_PATH, "w", encoding="utf-8") as f:
@@ -111,18 +122,12 @@ with st.sidebar:
         st.success(f"Guardado {CONFIG_PATH}")
 
 st.subheader("📥 Datos")
-col1, col2, col3 = st.columns(3)
-with col1:
-    ex_name_run = st.text_input("Exchange para descarga", value=ex_name, key="exchange_dl")
-with col2:
-    dl_timeframe = st.selectbox("Timeframe descarga", ["1s","1m","3m","5m","15m"], index=1, key="dl_tf")
-with col3:
-    since = st.text_input("Desde (ISO UTC, ej. 2024-01-01)", value="", key="since_iso")
-
-symbols_run = st.text_input("Símbolos a descargar", value=symbols, key="symbols_dl")
+st.caption("La precisión se elige automáticamente al mínimo disponible; el modelo puede reagrupar internamente")
+since = st.text_input("Desde (ISO UTC, ej. 2024-01-01)", value="", key="since_iso")
+st.write("Seleccionados: " + ", ".join(selected_symbols))
 if st.button("⬇️ Descargar histórico"):
     try:
-        ex = get_exchange(ex_name_run)
+        ex = get_exchange(use_testnet=use_testnet)
         from datetime import datetime, timezone
         since_ms = None
         if since:
@@ -131,13 +136,11 @@ if st.button("⬇️ Descargar histórico"):
                 since_ms = int(dt.timestamp()*1000)
             except Exception:
                 since_ms = None
-        for sym in symbols_run.split():
-            df = fetch_ohlcv(ex, sym, timeframe=dl_timeframe, since=since_ms)
-            if dl_timeframe == "1s" and df.empty:
-                st.warning(f"1s no disponible en {sym}; simulando desde 1m")
-                df_1m = fetch_ohlcv(ex, sym, timeframe="1m", since=since_ms)
-                df = simulate_1s_from_1m(df_1m)
-            path = save_history(df, raw_dir, ex_name_run, sym, dl_timeframe)
+        for sym in selected_symbols:
+            df = fetch_ohlcv(ex, sym, since=since_ms)
+            tf = df.attrs.get("timeframe", cfg.get("timeframe", "1m"))
+            cfg["timeframe"] = tf
+            path = save_history(df, str(raw_dir), "binance", sym, tf)
             st.success(f"Guardado: {path}")
     except Exception as e:
         st.error(f"Error en descarga: {e}")
@@ -148,12 +151,14 @@ with colt1:
     algo_run = st.selectbox("Algoritmo", ["ppo","dqn"], index=0 if algo=="ppo" else 1)
     timesteps = st.number_input("Timesteps", value=20000, step=1000)
 with colt2:
-    data_override = st.text_input("Ruta datos (opcional)", value="", key="train_data_override")
+    st.empty()
 
 if st.button("🚀 Entrenar"):
-    cmd = ["python", "-m", "src.training.train_drl", "--config", CONFIG_PATH, "--algo", algo_run, "--timesteps", str(int(timesteps))]
-    if data_override:
-        cmd.extend(["--data", data_override])
+    import tempfile, yaml
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg, tmp, sort_keys=False, allow_unicode=True)
+        cfg_path = tmp.name
+    cmd = ["python", "-m", "src.training.train_drl", "--config", cfg_path, "--algo", algo_run, "--timesteps", str(int(timesteps))]
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)
@@ -168,12 +173,14 @@ colb1, colb2 = st.columns(2)
 with colb1:
     policy = st.selectbox("Política", ["deterministic","stochastic","dqn"])
 with colb2:
-    data_eval = st.text_input("Ruta datos (opcional)", value="", key="eval_data_override")
+    st.empty()
 
 if st.button("📈 Evaluar"):
-    cmd = ["python", "-m", "src.backtest.evaluate", "--config", CONFIG_PATH, "--policy", policy]
-    if data_eval:
-        cmd.extend(["--data", data_eval])
+    import tempfile, yaml
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg, tmp, sort_keys=False, allow_unicode=True)
+        cfg_path = tmp.name
+    cmd = ["python", "-m", "src.backtest.evaluate", "--config", cfg_path, "--policy", policy]
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -22,6 +22,10 @@ def load_config(path: str, overrides: Dict[str, Any] | None = None) -> Dict[str,
         if v is not None:
             cfg.setdefault("env", {})[k] = v
 
+    use_testnet = os.getenv("BINANCE_USE_TESTNET")
+    if use_testnet is not None:
+        cfg["binance_use_testnet"] = use_testnet.lower() in ("1", "true", "yes")
+
     # Apply explicit overrides (e.g., CLI flags)
     if overrides:
         for k, v in overrides.items():

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Helper utilities for resolving common project directories."""
+
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _paths(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the ``paths`` section from the config or an empty mapping."""
+    return cfg.get("paths", {}) if isinstance(cfg, Mapping) else {}
+
+
+def get_raw_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory containing raw market data."""
+    return Path(_paths(cfg).get("raw_dir", "data/raw"))
+
+
+def get_reports_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory where evaluation reports are stored."""
+    return Path(_paths(cfg).get("reports_dir", "reports"))
+
+
+def get_checkpoints_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory for model checkpoints."""
+    return Path(_paths(cfg).get("checkpoints_dir", "checkpoints"))
+
+
+def ensure_dirs_exist(cfg: Mapping[str, Any]) -> None:
+    """Create common project directories if they do not already exist."""
+    for directory in [get_raw_dir(cfg), get_reports_dir(cfg), get_checkpoints_dir(cfg)]:
+        directory.mkdir(parents=True, exist_ok=True)

--- a/tests/test_binance_testnet.py
+++ b/tests/test_binance_testnet.py
@@ -1,0 +1,18 @@
+import os
+from src.data.ccxt_loader import get_exchange
+
+
+def _api_url(exchange):
+    api = exchange.urls["api"]
+    if isinstance(api, dict):
+        return api.get("public", "")
+    return api
+
+
+def test_get_exchange_respects_env(monkeypatch):
+    monkeypatch.setenv("BINANCE_USE_TESTNET", "true")
+    ex = get_exchange()
+    assert "testnet" in _api_url(ex).lower()
+    monkeypatch.setenv("BINANCE_USE_TESTNET", "false")
+    ex2 = get_exchange()
+    assert "testnet" not in _api_url(ex2).lower()

--- a/tests/test_evaluate_reports.py
+++ b/tests/test_evaluate_reports.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def test_evaluate_creates_report(tmp_path):
+    cfg = yaml.safe_load(Path('configs/default.yaml').read_text())
+    cfg_paths = cfg.setdefault('paths', {})
+    cfg_paths['raw_dir'] = str(tmp_path / 'raw')
+    cfg_paths['reports_dir'] = str(tmp_path / 'reports')
+    cfg_paths['checkpoints_dir'] = str(tmp_path / 'checkpoints')
+    cfg_path = tmp_path / 'cfg.yaml'
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    data_dir = Path(cfg_paths['raw_dir']) / 'binance' / 'BTC-USDT'
+    data_dir.mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            'open': [100, 103, 101, 101],
+            'high': [100, 103, 101, 101],
+            'low': [100, 103, 101, 101],
+            'close': [100, 103, 101, 101],
+        }
+    )
+    df.to_csv(data_dir / '1m.csv', index=False)
+
+    env = os.environ.copy()
+    env['MPLBACKEND'] = 'Agg'
+    subprocess.run(
+        ['python', '-m', 'src.backtest.evaluate', '--config', str(cfg_path), '--policy', 'deterministic'],
+        check=True,
+        env=env,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+    reports_dir = Path(cfg_paths['reports_dir'])
+    runs = list(reports_dir.iterdir())
+    assert len(runs) == 1
+    run_dir = runs[0]
+    assert (run_dir / 'metrics.json').is_file()
+    assert (run_dir / 'trades.csv').is_file()
+    assert (run_dir / 'equity.csv').is_file()

--- a/tests/test_symbol_discovery.py
+++ b/tests/test_symbol_discovery.py
@@ -1,0 +1,32 @@
+from src.data.symbol_discovery import discover_symbols
+
+
+class DummyEx:
+    def fetch_tickers(self):
+        return {
+            "BTC/USDT": {"quoteVolume": 100000},
+            "ETH/USDT": {"quoteVolume": 90000},
+            "USDC/USDT": {"quoteVolume": 80000},
+            "LTC/USDT": {"quoteVolume": 50000},
+            "BTC/USDC": {"quoteVolume": 120},
+            "XRP/USDT": {"quoteVolume": 70000},
+            "ETHUP/USDT": {"quoteVolume": 60000},
+            "BNB/USDT": {"quoteVolume": 65000},
+            "FOO/USDT": {"quoteVolume": 10},
+        }
+
+
+def test_discover_symbols_filters_and_sorts():
+    ex = DummyEx()
+    syms = discover_symbols(ex, top_n=5)
+    assert syms[0] == "BTC/USDT"
+    assert "USDC/USDT" not in syms  # filtered stablecoin
+    assert "ETHUP/USDT" not in syms  # filtered exotic suffix
+    assert len(syms) == 5
+    assert syms == [
+        "BTC/USDT",
+        "ETH/USDT",
+        "XRP/USDT",
+        "BNB/USDT",
+        "LTC/USDT",
+    ]

--- a/tests/test_timeframe_selection.py
+++ b/tests/test_timeframe_selection.py
@@ -1,0 +1,17 @@
+from src.data.ccxt_loader import fetch_ohlcv
+
+
+class DummyExchange:
+    timeframes = {"1m": 60, "5m": 300}
+
+    def fetch_ohlcv(self, symbol, timeframe, since=None, limit=1000):
+        assert timeframe == "1m"
+        return [[0, 1, 1, 1, 1, 1]]
+
+
+def test_fetch_ohlcv_auto_selects_smallest(caplog):
+    ex = DummyExchange()
+    with caplog.at_level("INFO"):
+        df = fetch_ohlcv(ex, "BTC/USDT")
+    assert df.attrs["timeframe"] == "1m"
+    assert "selected_timeframe=1m" in caplog.text


### PR DESCRIPTION
## Summary
- add `discover_symbols` helper to rank Binance markets by quote volume
- streamlit UI suggests top pairs with refresh & manual add and uses the selection for downloads and training
- training/evaluation run with a temporary config reflecting chosen symbols
- fetch layer auto-selects the smallest supported timeframe and logs the choice while UI removes manual timeframe inputs

## Testing
- `pytest tests/test_timeframe_selection.py -q`
- `pytest tests/test_symbol_discovery.py -q`
- `pytest tests/test_binance_testnet.py -q`
- `pytest tests/test_evaluate_reports.py::test_evaluate_creates_report -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68a485669a8c83289eb58f5ae0543fca