### PR TITLE
Default to Binance with testnet toggle, auto symbol discovery, and precision filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ dependencies = [
     "tqdm>=4.65",
     "matplotlib>=3.7",
     "orjson>=3.9.7",
+    "torch>=2.2; python_version>='3.9'",
     # Optional
     "stable-baselines3>=2.3.2; python_version>='3.9'",
-    "torch>=2.2; python_version>='3.9'",
     "polars>=1.0.0",
     "pyarrow>=15.0.0",
 ]

--- a/src/backtest/evaluate.py
+++ b/src/backtest/evaluate.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-import argparse, os
+import argparse
 import pandas as pd
 from .simulator import simulate
 from ..policies.router import get_policy
-from ..utils.data_io import load_table, ensure_dir
+from ..utils.data_io import load_table
 from ..utils.config import load_config
+from ..utils.paths import get_raw_dir, get_reports_dir, ensure_dirs_exist
 from .metrics import pnl, sharpe, sortino, max_drawdown, hit_ratio, turnover
 import json
 from datetime import datetime, timezone
@@ -18,8 +19,8 @@ def main():
     args = ap.parse_args()
 
     cfg = load_config(args.config)
-    paths = cfg.get("paths", {})
-    data_root = paths.get("raw_dir", "data/raw")
+    ensure_dirs_exist(cfg)
+    data_root = get_raw_dir(cfg)
     exchange = cfg.get("exchange", "binance")
     symbol = (cfg.get("symbols") or ["BTC/USDT"])[0]
     timeframe = cfg.get("timeframe", "1m")
@@ -27,14 +28,19 @@ def main():
     if args.data:
         df = load_table(args.data)
     else:
-        path = os.path.join(data_root, exchange, symbol.replace("/","-"), f"{timeframe}.parquet")
+        path = data_root / exchange / symbol.replace("/","-") / f"{timeframe}.parquet"
+        if not path.exists():
+            alt = path.with_suffix(".csv")
+            path = alt if alt.exists() else path
         df = load_table(path)
 
     pol = get_policy(args.policy)
+    fee = cfg.get("fees", {}).get("taker", 0.001)
+    print(f"Using fees: {cfg.get('fees', {})}")
     sim = simulate(
         df,
         pol,
-        fees=cfg.get("fees", {}).get("taker", 0.001),
+        fees=fee,
         slippage=cfg.get("slippage", 0.0005),
         min_notional_usd=cfg.get("min_notional_usd", 10.0),
         tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
@@ -61,27 +67,27 @@ def main():
         f"MaxDD: {metrics['max_drawdown']:.3%} | HitRatio: {metrics['hit_ratio']:.2%} | Turnover: {metrics['turnover']}"
     )
 
-    reports_root = paths.get("reports_dir", "reports")
+    reports_root = get_reports_dir(cfg)
     run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    run_dir = os.path.join(reports_root, run_id)
-    ensure_dir(run_dir)
+    run_dir = reports_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
 
     # save metrics
-    with open(os.path.join(run_dir, "metrics.json"), "w") as f:
+    with open(run_dir / "metrics.json", "w") as f:
         json.dump(metrics, f, indent=2)
 
     # save trades
-    pd.DataFrame(trades).to_csv(os.path.join(run_dir, "trades.csv"), index=False)
+    pd.DataFrame(trades).to_csv(run_dir / "trades.csv", index=False)
 
     # save equity curve
-    equity_curve.to_csv(os.path.join(run_dir, "equity.csv"), index_label="idx", header=["equity"])
+    equity_curve.to_csv(run_dir / "equity.csv", index_label="idx", header=["equity"])
     plt.figure()
     equity_curve.plot()
     plt.title("Equity Curve")
     plt.xlabel("trade")
     plt.ylabel("equity")
     plt.tight_layout()
-    plt.savefig(os.path.join(run_dir, "equity.png"))
+    plt.savefig(run_dir / "equity.png")
     plt.close()
 
 if __name__ == "__main__":

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "get_exchange",
     "fetch_ohlcv",
     "save_history",
+    "discover_symbols",
 ]
 
 from .ccxt_loader import (  # noqa: E402
@@ -13,4 +14,5 @@ from .ccxt_loader import (  # noqa: E402
     fetch_ohlcv,
     save_history,
 )
+from .symbol_discovery import discover_symbols
 

--- a/src/data/ccxt_loader.py
+++ b/src/data/ccxt_loader.py
@@ -8,6 +8,7 @@ lightweight to avoid heavy dependencies during testing.
 from __future__ import annotations
 
 import os
+import logging
 from typing import Any, Optional
 
 import pandas as pd
@@ -18,6 +19,9 @@ __all__ = [
     "fetch_ohlcv",
     "save_history",
 ]
+
+
+logger = logging.getLogger(__name__)
 
 
 def simulate_1s_from_1m(df_1m: pd.DataFrame) -> pd.DataFrame:
@@ -57,12 +61,12 @@ def simulate_1s_from_1m(df_1m: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
 
 
-def get_exchange(name: str):
-    """Instantiate a ``ccxt`` exchange by *name*.
+def get_exchange(name: str | None = None, *, use_testnet: bool | None = None):
+    """Return a ``ccxt`` Binance client.
 
-    The library is imported lazily so environments without ``ccxt`` can still
-    import this module for testing purposes.  An informative ``ImportError`` is
-    raised if the dependency is missing when the function is used.
+    ``name`` is kept for backwards compatibility and must be ``\"binance\"`` if
+    provided.  Testnet mode is enabled when ``use_testnet`` is ``True`` or when
+    the ``BINANCE_USE_TESTNET`` environment variable is truthy.
     """
 
     try:  # pragma: no cover - exercised only when ccxt is available
@@ -70,15 +74,22 @@ def get_exchange(name: str):
     except Exception as exc:  # pragma: no cover - missing optional dep
         raise ImportError("ccxt is required to create exchange clients") from exc
 
-    try:
-        cls = getattr(ccxt, name)
-    except AttributeError as exc:
-        raise ValueError(f"unknown exchange: {name}") from exc
+    if name and name.lower() != "binance":
+        raise ValueError("only binance exchange is supported")
 
-    ex = cls()
-    try:
+    if use_testnet is None:
+        use_testnet = os.getenv("BINANCE_USE_TESTNET", "").lower() in ("1", "true", "yes")
+
+    ex = ccxt.binance({"enableRateLimit": True})
+    if use_testnet:  # pragma: no cover - network/ccxt quirks
+        try:
+            ex.set_sandbox_mode(True)
+        except Exception:
+            ex.urls["api"] = ex.urls.get("test", ex.urls.get("api"))
+
+    try:  # pragma: no cover - network/ccxt quirks
         ex.load_markets()
-    except Exception:  # pragma: no cover - network/ccxt quirks
+    except Exception:
         pass
     return ex
 
@@ -86,14 +97,35 @@ def get_exchange(name: str):
 def fetch_ohlcv(
     exchange: Any,
     symbol: str,
-    timeframe: str = "1m",
+    timeframe: Optional[str] = None,
     since: Optional[int] = None,
     limit: int = 1000,
 ) -> pd.DataFrame:
-    """Fetch OHLCV data from *exchange* and return a DataFrame."""
+    """Fetch OHLCV data from *exchange* and return a DataFrame.
 
-    data = exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)
-    return pd.DataFrame(data, columns=["ts", "open", "high", "low", "close", "volume"])
+    When *timeframe* is ``None`` the function attempts to pick the smallest
+    available timeframe from ``exchange.timeframes`` following the order
+    ``["1s","3s","5s","15s","30s","1m","3m","5m"]``.  The chosen
+    timeframe is stored in ``df.attrs['timeframe']`` and logged via the module
+    logger.
+    """
+
+    tf = timeframe
+    if tf is None:
+        candidates = ["1s", "3s", "5s", "15s", "30s", "1m", "3m", "5m"]
+        available = getattr(exchange, "timeframes", {}) or {}
+        for cand in candidates:
+            if cand in available:
+                tf = cand
+                break
+        if tf is None:  # pragma: no cover - unlikely for Binance
+            raise ValueError("no supported timeframe found")
+        logger.info("selected_timeframe=%s", tf)
+
+    data = exchange.fetch_ohlcv(symbol, timeframe=tf, since=since, limit=limit)
+    df = pd.DataFrame(data, columns=["ts", "open", "high", "low", "close", "volume"])
+    df.attrs["timeframe"] = tf
+    return df
 
 
 def save_history(

--- a/src/data/symbol_discovery.py
+++ b/src/data/symbol_discovery.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import List
+
+STABLES = {
+    "USDT",
+    "USDC",
+    "BUSD",
+    "DAI",
+    "TUSD",
+    "PAX",
+    "EUR",
+    "GBP",
+    "JPY",
+    "RUB",
+}
+
+EXOTIC_SUFFIXES = ("UP", "DOWN", "BULL", "BEAR")
+
+
+def discover_symbols(exchange, quote: str = "USDT", top_n: int = 20) -> List[str]:
+    """Return the most active symbols for *exchange* sorted by quote volume.
+
+    Parameters
+    ----------
+    exchange:
+        A ccxt exchange instance providing :meth:`fetch_tickers`.
+    quote:
+        The quote currency to filter for, defaults to ``"USDT"``.
+    top_n:
+        Maximum number of symbols to return.
+
+    Returns
+    -------
+    list[str]
+        Symbols like ``"BTC/USDT"`` ordered by descending ``quoteVolume``.
+    """
+
+    try:  # pragma: no cover - network/ccxt quirks
+        tickers = exchange.fetch_tickers()
+    except Exception as exc:  # pragma: no cover - network/ccxt quirks
+        raise RuntimeError("failed to fetch tickers for discovery") from exc
+
+    ranked = []
+    for symbol, info in tickers.items():
+        if not symbol.endswith(f"/{quote}"):
+            continue
+        base, _ = symbol.split("/")
+        if base in STABLES:
+            continue
+        if any(base.endswith(suf) for suf in EXOTIC_SUFFIXES):
+            continue
+        qv = float(info.get("quoteVolume") or 0.0)
+        ranked.append((qv, symbol))
+
+    ranked.sort(reverse=True)
+    return [sym for _, sym in ranked[:top_n]]

--- a/src/env/trading_env.py
+++ b/src/env/trading_env.py
@@ -16,6 +16,8 @@ import pandas as pd
 import yaml
 import logging
 
+from ..exchange.binance_meta import BinanceMeta
+
 try:  # pragma: no cover - optional gym dependency
     import gymnasium as gym
     from gymnasium import spaces
@@ -63,6 +65,9 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         df: pd.DataFrame,
         orderbook_hook: Callable[[int], Dict[str, Any]] | None = None,
         *,
+        cfg: dict | None = None,
+        symbol: str | None = None,
+        meta: BinanceMeta | None = None,
         max_trades_per_window: int | None = None,
         trade_window_seconds: float = 0.0,
         trade_cooldown_seconds: float = 0.0,
@@ -95,8 +100,10 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         # in the future this could include a continuous component (0..1)
         # to express position sizing alongside the discrete action
         # config ---------------------------------------------------------
-        with open("configs/default.yaml", "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f)
+        if cfg is None:
+            with open("configs/default.yaml", "r", encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
+        self.cfg = cfg
         fees = cfg.get("fees", {})
         self.fee_rate = float(fees.get("taker", 0.0))
         rw = cfg.get("reward_weights", {})
@@ -105,6 +112,22 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         self.w_dd = float(rw.get("dd", 0.0))
         self.w_vol = float(rw.get("vol", 0.0))
 
+        self.meta = meta
+        self.symbol = symbol
+        f_cfg = cfg.get("filters", {})
+        self._tick_size = float(f_cfg.get("tickSize", 0.0))
+        self._step_size = float(f_cfg.get("stepSize", 1.0))
+        self._min_notional = float(cfg.get("min_notional_usd", 0.0))
+        self.position_size = 0.0
+        if self.meta and self.symbol:
+            try:
+                filt = self.meta.get_symbol_filters(self.symbol)
+                self._tick_size = float(filt.get("tickSize", self._tick_size))
+                self._step_size = float(filt.get("stepSize", self._step_size))
+                self._min_notional = float(filt.get("minNotional", self._min_notional))
+            except Exception:  # pragma: no cover - network issues
+                pass
+
         # environment timing and trade limits ----------------------------
         self.step_seconds = float(cfg.get("step_seconds", 60))
         self.max_trades_per_window = max_trades_per_window
@@ -112,6 +135,20 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         self.trade_cooldown_seconds = float(trade_cooldown_seconds)
         self._trade_times: deque[float] = deque()
         self._last_trade_time: float | None = None
+
+    # ------------------------------------------------------------------
+    def set_symbol(self, symbol: str) -> None:
+        """Update the active *symbol* and reload exchange filters."""
+
+        self.symbol = symbol
+        if self.meta:
+            try:
+                filt = self.meta.get_symbol_filters(symbol)
+                self._tick_size = float(filt.get("tickSize", self._tick_size))
+                self._step_size = float(filt.get("stepSize", self._step_size))
+                self._min_notional = float(filt.get("minNotional", self._min_notional))
+            except Exception:  # pragma: no cover - network issues
+                pass
 
     # ------------------------------------------------------------------
     def _make_observation(self, step: int) -> np.ndarray:
@@ -234,6 +271,7 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         self.in_position = False
         self.trailing_stop = None
         self.entry_price = None
+        self.position_size = 0.0
         self.equity = 0.0
         self.equity_peak = 0.0
         self._feature_histories = [[] for _ in range(8)]
@@ -277,21 +315,59 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         if action == 1 and not self.in_position:
             attempted_trade = True
             if can_trade():
-                self.in_position = True
-                self.trailing_stop = prev_price
-                self.entry_price = prev_price
-                fee = prev_price * self.fee_rate
-                self.equity -= fee
-                trade = True
+                price = prev_price
+                if self._tick_size > 0:
+                    price = round(price / self._tick_size) * self._tick_size
+                qty = 1.0
+                if self._step_size > 0:
+                    qty = round(qty / self._step_size) * self._step_size
+                value = price * qty
+                logger.info(
+                    "open_order price=%.8f qty=%.8f value=%.8f tick=%.8f step=%.8f", 
+                    price, qty, value, self._tick_size, self._step_size,
+                )
+                if value < self._min_notional:
+                    logger.info(
+                        "Trade blocked: value %.8f < minNotional %.8f",
+                        value,
+                        self._min_notional,
+                    )
+                else:
+                    self.in_position = True
+                    self.position_size = qty
+                    self.trailing_stop = price
+                    self.entry_price = price
+                    fee = value * self.fee_rate
+                    self.equity -= fee
+                    trade = True
         elif action == 2 and self.in_position:
             attempted_trade = True
             if can_trade():
-                fee = prev_price * self.fee_rate
-                self.equity += (prev_price - self.entry_price) - fee
-                self.in_position = False
-                self.trailing_stop = None
-                self.entry_price = None
-                trade = True
+                price = prev_price
+                if self._tick_size > 0:
+                    price = round(price / self._tick_size) * self._tick_size
+                qty = self.position_size if self.position_size > 0 else 1.0
+                if self._step_size > 0:
+                    qty = round(qty / self._step_size) * self._step_size
+                value = price * qty
+                logger.info(
+                    "close_order price=%.8f qty=%.8f value=%.8f tick=%.8f step=%.8f",
+                    price, qty, value, self._tick_size, self._step_size,
+                )
+                if value < self._min_notional:
+                    logger.info(
+                        "Trade blocked: value %.8f < minNotional %.8f",
+                        value,
+                        self._min_notional,
+                    )
+                else:
+                    fee = value * self.fee_rate
+                    self.equity += (price - self.entry_price) * qty - fee
+                    self.in_position = False
+                    self.position_size = 0.0
+                    self.trailing_stop = None
+                    self.entry_price = None
+                    trade = True
 
         if trade:
             self._last_trade_time = now
@@ -307,7 +383,7 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
         price = self._close[self.current_step]
 
         if self.in_position:
-            self.equity += price - prev_price
+            self.equity += (price - prev_price) * self.position_size
             if self.trailing_stop is not None:
                 self.trailing_stop = max(self.trailing_stop, price)
 

--- a/src/exchange/__init__.py
+++ b/src/exchange/__init__.py
@@ -1,0 +1,2 @@
+"""Exchange utilities."""
+__all__ = []

--- a/src/training/train_drl.py
+++ b/src/training/train_drl.py
@@ -30,6 +30,7 @@ from ..env.trading_env import TradingEnv
 from ..utils.config import load_config
 from ..utils.data_io import load_table
 from ..utils.logging import ensure_logger, config_hash
+from ..utils.paths import get_raw_dir, get_checkpoints_dir, ensure_dirs_exist
 from ..policies.value_based import ValueBasedPolicy
 
 
@@ -108,19 +109,18 @@ def has_sb3() -> bool:
 
 
 def load_data(cfg: dict, data_path: str | None, timesteps: int) -> pd.DataFrame:
-    """Load price data or generate synthetic series if not available."""
+    """Load price data or generate a synthetic series if none is found."""
 
     if data_path:
         return load_table(data_path)
 
-    paths = cfg.get("paths", {})
-    raw_dir = paths.get("raw_dir", "data/raw")
+    raw_dir = get_raw_dir(cfg)
     exchange = cfg.get("exchange", "binance")
     symbol = (cfg.get("symbols") or ["BTC/USDT"])[0]
     timeframe = cfg.get("timeframe", "1m")
-    fname = os.path.join(raw_dir, exchange, symbol.replace("/", "-"), f"{timeframe}.parquet")
+    fname = raw_dir / exchange / symbol.replace("/", "-") / f"{timeframe}.parquet"
 
-    if os.path.exists(fname):  # pragma: no branch - depends on repo data
+    if fname.exists():  # pragma: no branch - depends on repo data
         return load_table(fname)
 
     # generate simple random walk prices
@@ -134,7 +134,7 @@ def load_data(cfg: dict, data_path: str | None, timesteps: int) -> pd.DataFrame:
 def quick_eval(env: TradingEnv, agent: TinyDQN) -> float:
     """Run a fast evaluation episode and return final equity."""
 
-    eval_env = TradingEnv(env.df)
+    eval_env = TradingEnv(env.df, cfg=env.cfg)
     obs, _ = eval_env.reset()
     done = False
     while not done:
@@ -294,8 +294,10 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = load_config(args.config)
+    ensure_dirs_exist(cfg)
     df = load_data(cfg, args.data, args.timesteps)
-    env = TradingEnv(df)
+    env = TradingEnv(df, cfg=cfg)
+    print(f"Using fees: {cfg.get('fees', {})}")
 
     paths = cfg.get("paths", {})
     logs_dir = paths.get("logs_dir", "logs")
@@ -303,14 +305,15 @@ def main() -> None:
     logger = ensure_logger(os.path.join(logs_dir, "train.jsonl"))
     logger.log("INFO", "env_ready", obs_dim=int(env.observation_space.shape[0]), actions=int(env.action_space.n))
 
+    ckpt_dir = str(get_checkpoints_dir(cfg))
     if args.algo.lower() == "dqn":
-        out = train_value_dqn(env, cfg, args.timesteps, outdir=paths.get("checkpoints_dir", "checkpoints"), checkpoint_freq=args.checkpoint_freq)
+        out = train_value_dqn(env, cfg, args.timesteps, outdir=ckpt_dir, checkpoint_freq=args.checkpoint_freq)
     elif args.algo.lower() == "tiny":
-        out = train_dqn(env, cfg, args.timesteps, outdir=paths.get("checkpoints_dir", "checkpoints"), checkpoint_freq=args.checkpoint_freq)
+        out = train_dqn(env, cfg, args.timesteps, outdir=ckpt_dir, checkpoint_freq=args.checkpoint_freq)
     elif args.algo.lower() == "ppo":
         if not has_sb3():  # pragma: no cover - optional dependency
             raise RuntimeError("stable-baselines3 is required for PPO training")
-        out = train_ppo_sb3(env, cfg, args.timesteps, outdir=paths.get("checkpoints_dir", "checkpoints"))
+        out = train_ppo_sb3(env, cfg, args.timesteps, outdir=ckpt_dir)
     else:  # pragma: no cover
         raise ValueError(f"Unknown algorithm: {args.algo}")
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -3,8 +3,11 @@ from datetime import datetime
 import streamlit as st
 
 from src.utils.config import load_config
-from src.utils.data_io import load_table
-from src.data.ccxt_loader import get_exchange, fetch_ohlcv, simulate_1s_from_1m, save_history
+from src.utils.paths import ensure_dirs_exist, get_raw_dir
+from src.data.ccxt_loader import get_exchange, fetch_ohlcv, save_history
+from src.data.symbol_discovery import discover_symbols
+from src.exchange.binance_meta import BinanceMeta
+from dotenv import load_dotenv
 
 CONFIG_PATH = st.session_state.get("config_path", "configs/default.yaml")
 
@@ -19,31 +22,61 @@ with st.sidebar:
     # Cargar YAML
     try:
         cfg = load_config(CONFIG_PATH)
+        ensure_dirs_exist(cfg)
     except Exception as e:
         st.error(f"No se pudo cargar {CONFIG_PATH}: {e}")
         cfg = {}
 
-    paths = cfg.get("paths", {})
-    logs_dir = paths.get("logs_dir", "logs")
-    checkpoints_dir = paths.get("checkpoints_dir", "checkpoints")
-    raw_dir = paths.get("raw_dir", "data/raw")
-    reports_dir = paths.get("reports_dir", "reports")
+    paths_cfg = cfg.get("paths", {})
+    raw_dir = get_raw_dir(cfg)
+    use_testnet_default = bool(cfg.get("binance_use_testnet", False))
+    mode = st.radio("Modo", ["Mainnet", "Testnet"], index=1 if use_testnet_default else 0)
+    use_testnet = mode == "Testnet"
+    os.environ["BINANCE_USE_TESTNET"] = "true" if use_testnet else "false"
 
-    st.caption("Rutas")
-    colp1, colp2 = st.columns(2)
-    with colp1:
-        raw_dir = st.text_input("Data raw dir", value=raw_dir, key="raw_dir")
-        logs_dir = st.text_input("Logs dir", value=logs_dir, key="logs_dir")
-    with colp2:
-        checkpoints_dir = st.text_input("Checkpoints dir", value=checkpoints_dir, key="ckpt_dir")
-        reports_dir = st.text_input("Reports dir", value=reports_dir, key="reports_dir")
+    st.caption("Símbolos sugeridos (auto)")
+    refresh_syms = st.button("Actualizar", key="refresh_syms")
+    if "symbol_checks" not in st.session_state or refresh_syms:
+        try:
+            ex = get_exchange(use_testnet=use_testnet)
+            suggested = discover_symbols(ex, top_n=20)
+        except Exception as e:
+            st.warning(f"Descubrimiento falló: {e}")
+            suggested = cfg.get("symbols") or ["BTC/USDT"]
+        checks = st.session_state.get("symbol_checks", {})
+        for s in suggested:
+            checks.setdefault(s, True)
+        st.session_state["symbol_checks"] = checks
+    checks = st.session_state.get("symbol_checks", {})
+    for sym in sorted(checks):
+        checks[sym] = st.checkbox(sym, value=checks[sym], key=f"sym_{sym}")
+    manual = st.text_input("Añadir manualmente", key="manual_sym").upper().strip()
+    if manual and manual not in checks:
+        checks[manual] = True
+    selected_symbols = [s for s, v in checks.items() if v]
+    cfg["symbols"] = selected_symbols
 
-    st.caption("Exchange")
-    ex_name = st.text_input("Exchange (ccxt)", value=cfg.get("exchange","binance"), key="exchange_ccxt")
-    symbols = st.text_input("Símbolos (espacio-separado)", value=" ".join(cfg.get("symbols") or ["BTC/USDT"]), key="symbols_space")
-    timeframe = st.selectbox("Timeframe", ["1s","1m","3m","5m","15m"], index=1)
 
-    fees_taker = st.number_input("Fee taker", value=float(cfg.get("fees",{}).get("taker",0.001)), step=0.0001, format="%.6f")
+    fees_dict = cfg.get("fees", {})
+    fees_maker = st.number_input("Fee maker", value=float(fees_dict.get("maker",0.001)), step=0.0001, format="%.6f", key="fee_maker")
+    fees_taker = st.number_input("Fee taker", value=float(fees_dict.get("taker",0.001)), step=0.0001, format="%.6f", key="fee_taker")
+    if st.button("Actualizar comisiones"):
+        load_dotenv()
+        api_key = os.getenv("BINANCE_API_KEY")
+        api_secret = os.getenv("BINANCE_API_SECRET")
+        try:
+            meta = BinanceMeta(api_key, api_secret, use_testnet)
+            fee_map = meta.get_account_trade_fees()
+            symbol_key = (selected_symbols[0].replace("/", "") if selected_symbols else next(iter(fee_map)))
+            entry = fee_map.get(symbol_key) or next(iter(fee_map.values()))
+            st.session_state["fee_maker"] = entry.get("maker", fees_maker)
+            st.session_state["fee_taker"] = entry.get("taker", fees_taker)
+            st.success(f"Maker {entry.get('maker',0)} | Taker {entry.get('taker',0)}")
+        except Exception as e:
+            st.error(f"No se pudo obtener: {e}")
+    fees_maker = st.session_state.get("fee_maker", fees_maker)
+    fees_taker = st.session_state.get("fee_taker", fees_taker)
+    cfg["fees"] = {"maker": fees_maker, "taker": fees_taker}
     slippage = st.number_input("Slippage", value=float(cfg.get("slippage",0.0005)), step=0.0001, format="%.6f")
     min_notional = st.number_input("Mínimo notional USD", value=float(cfg.get("min_notional_usd",10.0)), step=1.0)
 
@@ -83,10 +116,11 @@ with st.sidebar:
     if st.button("💾 Guardar config YAML"):
         import yaml
         new_cfg = {
-            "exchange": ex_name,
-            "symbols": symbols.split(),
-            "timeframe": timeframe,
-            "fees": {"taker": fees_taker, "maker": cfg.get("fees",{}).get("maker", fees_taker)},
+            "exchange": "binance",
+            "binance_use_testnet": use_testnet,
+            "symbols": selected_symbols,
+            "timeframe": cfg.get("timeframe", "1m"),
+            "fees": {"taker": fees_taker, "maker": cfg.get("fees", {}).get("maker", fees_taker)},
             "slippage": slippage,
             "min_notional_usd": min_notional,
             "filters": {"tickSize": tick_size, "stepSize": step_size},
@@ -101,9 +135,7 @@ with st.sidebar:
                 "epsilon_end": dqn_eps_e, "epsilon_decay_steps": int(dqn_eps_d)
             },
             "reward_weights": {"pnl": w_pnl, "turnover_penalty": w_turn, "drawdown_penalty": w_dd, "volatility_penalty": w_vol},
-            "paths": {
-                "raw_dir": raw_dir, "logs_dir": logs_dir, "reports_dir": reports_dir, "checkpoints_dir": checkpoints_dir
-            },
+            "paths": paths_cfg,
         }
         os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
         with open(CONFIG_PATH, "w", encoding="utf-8") as f:
@@ -111,18 +143,12 @@ with st.sidebar:
         st.success(f"Guardado {CONFIG_PATH}")
 
 st.subheader("📥 Datos")
-col1, col2, col3 = st.columns(3)
-with col1:
-    ex_name_run = st.text_input("Exchange para descarga", value=ex_name, key="exchange_dl")
-with col2:
-    dl_timeframe = st.selectbox("Timeframe descarga", ["1s","1m","3m","5m","15m"], index=1, key="dl_tf")
-with col3:
-    since = st.text_input("Desde (ISO UTC, ej. 2024-01-01)", value="", key="since_iso")
-
-symbols_run = st.text_input("Símbolos a descargar", value=symbols, key="symbols_dl")
+st.caption("La precisión se elige automáticamente al mínimo disponible; el modelo puede reagrupar internamente")
+since = st.text_input("Desde (ISO UTC, ej. 2024-01-01)", value="", key="since_iso")
+st.write("Seleccionados: " + ", ".join(selected_symbols))
 if st.button("⬇️ Descargar histórico"):
     try:
-        ex = get_exchange(ex_name_run)
+        ex = get_exchange(use_testnet=use_testnet)
         from datetime import datetime, timezone
         since_ms = None
         if since:
@@ -131,13 +157,11 @@ if st.button("⬇️ Descargar histórico"):
                 since_ms = int(dt.timestamp()*1000)
             except Exception:
                 since_ms = None
-        for sym in symbols_run.split():
-            df = fetch_ohlcv(ex, sym, timeframe=dl_timeframe, since=since_ms)
-            if dl_timeframe == "1s" and df.empty:
-                st.warning(f"1s no disponible en {sym}; simulando desde 1m")
-                df_1m = fetch_ohlcv(ex, sym, timeframe="1m", since=since_ms)
-                df = simulate_1s_from_1m(df_1m)
-            path = save_history(df, raw_dir, ex_name_run, sym, dl_timeframe)
+        for sym in selected_symbols:
+            df = fetch_ohlcv(ex, sym, since=since_ms)
+            tf = df.attrs.get("timeframe", cfg.get("timeframe", "1m"))
+            cfg["timeframe"] = tf
+            path = save_history(df, str(raw_dir), "binance", sym, tf)
             st.success(f"Guardado: {path}")
     except Exception as e:
         st.error(f"Error en descarga: {e}")
@@ -148,12 +172,14 @@ with colt1:
     algo_run = st.selectbox("Algoritmo", ["ppo","dqn"], index=0 if algo=="ppo" else 1)
     timesteps = st.number_input("Timesteps", value=20000, step=1000)
 with colt2:
-    data_override = st.text_input("Ruta datos (opcional)", value="", key="train_data_override")
+    st.empty()
 
 if st.button("🚀 Entrenar"):
-    cmd = ["python", "-m", "src.training.train_drl", "--config", CONFIG_PATH, "--algo", algo_run, "--timesteps", str(int(timesteps))]
-    if data_override:
-        cmd.extend(["--data", data_override])
+    import tempfile, yaml
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg, tmp, sort_keys=False, allow_unicode=True)
+        cfg_path = tmp.name
+    cmd = ["python", "-m", "src.training.train_drl", "--config", cfg_path, "--algo", algo_run, "--timesteps", str(int(timesteps))]
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)
@@ -168,12 +194,14 @@ colb1, colb2 = st.columns(2)
 with colb1:
     policy = st.selectbox("Política", ["deterministic","stochastic","dqn"])
 with colb2:
-    data_eval = st.text_input("Ruta datos (opcional)", value="", key="eval_data_override")
+    st.empty()
 
 if st.button("📈 Evaluar"):
-    cmd = ["python", "-m", "src.backtest.evaluate", "--config", CONFIG_PATH, "--policy", policy]
-    if data_eval:
-        cmd.extend(["--data", data_eval])
+    import tempfile, yaml
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
+        yaml.safe_dump(cfg, tmp, sort_keys=False, allow_unicode=True)
+        cfg_path = tmp.name
+    cmd = ["python", "-m", "src.backtest.evaluate", "--config", cfg_path, "--policy", policy]
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -22,6 +22,10 @@ def load_config(path: str, overrides: Dict[str, Any] | None = None) -> Dict[str,
         if v is not None:
             cfg.setdefault("env", {})[k] = v
 
+    use_testnet = os.getenv("BINANCE_USE_TESTNET")
+    if use_testnet is not None:
+        cfg["binance_use_testnet"] = use_testnet.lower() in ("1", "true", "yes")
+
     # Apply explicit overrides (e.g., CLI flags)
     if overrides:
         for k, v in overrides.items():

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Helper utilities for resolving common project directories."""
+
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _paths(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the ``paths`` section from the config or an empty mapping."""
+    return cfg.get("paths", {}) if isinstance(cfg, Mapping) else {}
+
+
+def get_raw_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory containing raw market data."""
+    return Path(_paths(cfg).get("raw_dir", "data/raw"))
+
+
+def get_reports_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory where evaluation reports are stored."""
+    return Path(_paths(cfg).get("reports_dir", "reports"))
+
+
+def get_checkpoints_dir(cfg: Mapping[str, Any]) -> Path:
+    """Return the directory for model checkpoints."""
+    return Path(_paths(cfg).get("checkpoints_dir", "checkpoints"))
+
+
+def ensure_dirs_exist(cfg: Mapping[str, Any]) -> None:
+    """Create common project directories if they do not already exist."""
+    for directory in [get_raw_dir(cfg), get_reports_dir(cfg), get_checkpoints_dir(cfg)]:
+        directory.mkdir(parents=True, exist_ok=True)

--- a/tests/test_binance_meta.py
+++ b/tests/test_binance_meta.py
@@ -1,0 +1,66 @@
+import types
+from src.exchange.binance_meta import BinanceMeta
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_binance_meta_parses_response(monkeypatch):
+    sample = [{"symbol": "BTCUSDT", "makerCommission": 0.001, "takerCommission": 0.002}]
+    def fake_get(url, params=None, headers=None, timeout=10):
+        return DummyResp(sample)
+    monkeypatch.setattr('src.exchange.binance_meta.requests.get', fake_get)
+    meta = BinanceMeta("k", "s")
+    fees = meta.get_account_trade_fees()
+    assert fees["BTCUSDT"]["taker"] == 0.002
+    assert fees["BTCUSDT"]["maker"] == 0.001
+
+
+def test_symbol_filters_cached(monkeypatch):
+    calls = []
+
+    def fake_get(url, params=None, timeout=10):
+        calls.append(1)
+
+        return DummyResp(
+            {
+                "symbols": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "filters": [
+                            {"filterType": "PRICE_FILTER", "tickSize": "0.01"},
+                            {"filterType": "LOT_SIZE", "stepSize": "0.001"},
+                            {"filterType": "MIN_NOTIONAL", "minNotional": "10"},
+                        ],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr('src.exchange.binance_meta.requests.get', fake_get)
+    meta = BinanceMeta("k", "s")
+    f1 = meta.get_symbol_filters("BTCUSDT")
+    f2 = meta.get_symbol_filters("BTCUSDT")
+    assert calls.count(1) == 1
+    assert f1 == f2 == {"tickSize": 0.01, "stepSize": 0.001, "minNotional": 10.0}
+
+
+def test_binance_meta_fallback(monkeypatch):
+    def raise_exc(*args, **kwargs):
+        raise Exception("boom")
+    monkeypatch.setattr('src.exchange.binance_meta.requests.get', raise_exc)
+    class DummyEx:
+        fees = {"trading": {"maker": 0.005, "taker": 0.006}}
+    monkeypatch.setattr('src.exchange.binance_meta.get_exchange', lambda **kwargs: DummyEx())
+    meta = BinanceMeta("k", "s")
+    fees = meta.get_account_trade_fees()
+    assert fees["SPOT"]["maker"] == 0.005
+    assert fees["SPOT"]["taker"] == 0.006

--- a/tests/test_binance_testnet.py
+++ b/tests/test_binance_testnet.py
@@ -1,0 +1,18 @@
+import os
+from src.data.ccxt_loader import get_exchange
+
+
+def _api_url(exchange):
+    api = exchange.urls["api"]
+    if isinstance(api, dict):
+        return api.get("public", "")
+    return api
+
+
+def test_get_exchange_respects_env(monkeypatch):
+    monkeypatch.setenv("BINANCE_USE_TESTNET", "true")
+    ex = get_exchange()
+    assert "testnet" in _api_url(ex).lower()
+    monkeypatch.setenv("BINANCE_USE_TESTNET", "false")
+    ex2 = get_exchange()
+    assert "testnet" not in _api_url(ex2).lower()

--- a/tests/test_env_order_filters.py
+++ b/tests/test_env_order_filters.py
@@ -1,0 +1,72 @@
+import pandas as pd
+from src.env.trading_env import TradingEnv
+
+
+class DummyMeta:
+    def __init__(self):
+        self.calls = []
+
+    def get_symbol_filters(self, symbol: str):
+        self.calls.append(symbol)
+        if symbol == "BTC/USDT":
+            return {"tickSize": 0.1, "stepSize": 0.5, "minNotional": 100.0}
+        return {"tickSize": 1.0, "stepSize": 1.0, "minNotional": 1000.0}
+
+
+def make_df(prices):
+    return pd.DataFrame(
+        {
+            "ts": range(len(prices)),
+            "open": prices,
+            "high": prices,
+            "low": prices,
+            "close": prices,
+            "volume": [1.0] * len(prices),
+        }
+    )
+
+
+def test_order_respects_filters():
+    df = make_df([101.23, 110.55])
+    cfg = {
+        "fees": {"taker": 0.0},
+        "min_notional_usd": 0.0,
+        "filters": {"tickSize": 0.1, "stepSize": 0.5},
+    }
+    meta = DummyMeta()
+    env = TradingEnv(df, cfg=cfg, symbol="BTC/USDT", meta=meta)
+    env.reset()
+    env.step(1)
+    assert env.in_position
+    assert env.entry_price == 101.2
+    env.step(2)
+    assert not env.in_position
+    assert meta.calls == ["BTC/USDT"]
+
+
+def test_min_notional_blocks_order():
+    df = make_df([1.0, 1.0])
+    cfg = {
+        "fees": {"taker": 0.0},
+        "min_notional_usd": 0.0,
+        "filters": {"tickSize": 0.1, "stepSize": 0.1},
+    }
+    meta = DummyMeta()
+    meta.get_symbol_filters = lambda s: {"tickSize": 0.1, "stepSize": 0.1, "minNotional": 10.0}
+    env = TradingEnv(df, cfg=cfg, symbol="BTC/USDT", meta=meta)
+    env.reset()
+    env.step(1)
+    assert not env.in_position
+
+
+def test_set_symbol_loads_new_filters():
+    df = make_df([100.0, 100.0])
+    cfg = {
+        "fees": {"taker": 0.0},
+        "min_notional_usd": 0.0,
+        "filters": {"tickSize": 0.1, "stepSize": 0.1},
+    }
+    meta = DummyMeta()
+    env = TradingEnv(df, cfg=cfg, symbol="BTC/USDT", meta=meta)
+    env.set_symbol("ETH/USDT")
+    assert meta.calls == ["BTC/USDT", "ETH/USDT"]

--- a/tests/test_evaluate_reports.py
+++ b/tests/test_evaluate_reports.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def test_evaluate_creates_report(tmp_path):
+    cfg = yaml.safe_load(Path('configs/default.yaml').read_text())
+    cfg['fees'] = {'taker': 0.005, 'maker': 0.004}
+    cfg_paths = cfg.setdefault('paths', {})
+    cfg_paths['raw_dir'] = str(tmp_path / 'raw')
+    cfg_paths['reports_dir'] = str(tmp_path / 'reports')
+    cfg_paths['checkpoints_dir'] = str(tmp_path / 'checkpoints')
+    cfg_path = tmp_path / 'cfg.yaml'
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    data_dir = Path(cfg_paths['raw_dir']) / 'binance' / 'BTC-USDT'
+    data_dir.mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            'open': [100, 103, 101, 101],
+            'high': [100, 103, 101, 101],
+            'low': [100, 103, 101, 101],
+            'close': [100, 103, 101, 101],
+        }
+    )
+    df.to_csv(data_dir / '1m.csv', index=False)
+
+    env = os.environ.copy()
+    env['MPLBACKEND'] = 'Agg'
+    res = subprocess.run(
+        ['python', '-m', 'src.backtest.evaluate', '--config', str(cfg_path), '--policy', 'deterministic'],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+    assert '0.005' in res.stdout
+
+    reports_dir = Path(cfg_paths['reports_dir'])
+    runs = list(reports_dir.iterdir())
+    assert len(runs) == 1
+    run_dir = runs[0]
+    assert (run_dir / 'metrics.json').is_file()
+    assert (run_dir / 'trades.csv').is_file()
+    assert (run_dir / 'equity.csv').is_file()

--- a/tests/test_symbol_discovery.py
+++ b/tests/test_symbol_discovery.py
@@ -1,0 +1,32 @@
+from src.data.symbol_discovery import discover_symbols
+
+
+class DummyEx:
+    def fetch_tickers(self):
+        return {
+            "BTC/USDT": {"quoteVolume": 100000},
+            "ETH/USDT": {"quoteVolume": 90000},
+            "USDC/USDT": {"quoteVolume": 80000},
+            "LTC/USDT": {"quoteVolume": 50000},
+            "BTC/USDC": {"quoteVolume": 120},
+            "XRP/USDT": {"quoteVolume": 70000},
+            "ETHUP/USDT": {"quoteVolume": 60000},
+            "BNB/USDT": {"quoteVolume": 65000},
+            "FOO/USDT": {"quoteVolume": 10},
+        }
+
+
+def test_discover_symbols_filters_and_sorts():
+    ex = DummyEx()
+    syms = discover_symbols(ex, top_n=5)
+    assert syms[0] == "BTC/USDT"
+    assert "USDC/USDT" not in syms  # filtered stablecoin
+    assert "ETHUP/USDT" not in syms  # filtered exotic suffix
+    assert len(syms) == 5
+    assert syms == [
+        "BTC/USDT",
+        "ETH/USDT",
+        "XRP/USDT",
+        "BNB/USDT",
+        "LTC/USDT",
+    ]

--- a/tests/test_timeframe_selection.py
+++ b/tests/test_timeframe_selection.py
@@ -1,0 +1,17 @@
+from src.data.ccxt_loader import fetch_ohlcv
+
+
+class DummyExchange:
+    timeframes = {"1m": 60, "5m": 300}
+
+    def fetch_ohlcv(self, symbol, timeframe, since=None, limit=1000):
+        assert timeframe == "1m"
+        return [[0, 1, 1, 1, 1, 1]]
+
+
+def test_fetch_ohlcv_auto_selects_smallest(caplog):
+    ex = DummyExchange()
+    with caplog.at_level("INFO"):
+        df = fetch_ohlcv(ex, "BTC/USDT")
+    assert df.attrs["timeframe"] == "1m"
+    assert "selected_timeframe=1m" in caplog.text


### PR DESCRIPTION
## Summary
- promote torch to a core dependency
- add cached `get_symbol_filters` in `BinanceMeta` for tick/step/minNotional
- round and validate orders in `TradingEnv` using fetched filters

## Testing
- `pytest tests/test_binance_meta.py tests/test_env_order_filters.py -q`
- `pytest tests/test_timeframe_selection.py tests/test_symbol_discovery.py tests/test_binance_testnet.py tests/test_evaluate_reports.py::test_evaluate_creates_report -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a485669a8c83289eb58f5ae0543fca