### PR TITLE
Add adaptive hybrid policy and evaluation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ reports/
 !src/data/universe/liquid_universe.csv
 !src/env/
 !src/env/**
+!src/reports/
+!src/reports/**
 
 # OS files
 .DS_Store

--- a/src/backtest/evaluate.py
+++ b/src/backtest/evaluate.py
@@ -3,9 +3,11 @@ import argparse
 import pandas as pd
 from .simulator import simulate
 from ..policies.router import get_policy
+from ..policies.hybrid import HybridPolicy
 from ..utils.data_io import load_table
 from ..utils.config import load_config
 from ..utils.paths import get_raw_dir, get_reports_dir, ensure_dirs_exist
+from ..reports.human_friendly import write_readme
 from .metrics import pnl, sharpe, sortino, max_drawdown, hit_ratio, turnover
 import json
 from datetime import datetime, timezone
@@ -34,20 +36,71 @@ def main():
             path = alt if alt.exists() else path
         df = load_table(path)
 
-    pol = get_policy(args.policy)
     fee = cfg.get("fees", {}).get("taker", 0.001)
     print(f"Using fees: {cfg.get('fees', {})}")
-    sim = simulate(
-        df,
-        pol,
-        fees=fee,
-        slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
-        min_notional_usd=cfg.get("min_notional_usd", 10.0),
-        tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
-        step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
-        symbol=symbol,
-        slippage_depth=int(cfg.get("slippage_depth", 50)),
-    )
+
+    if args.policy.lower() == "hybrid":
+        names = ["deterministic", "stochastic", "value_based"]
+        defaults = [0.5, 0.3, 0.2]
+        policies = {}
+        init_w = {}
+        for n, w in zip(names, defaults):
+            try:
+                policies[n] = get_policy(n)
+                init_w[n] = w
+            except Exception:
+                pass
+        pol = HybridPolicy(policies, init_w)
+
+        block_size = int(cfg.get("hybrid_block_size", 1440))
+        for start in range(0, len(df), block_size):
+            block = df.iloc[start : start + block_size]
+            metrics_block = {}
+            for n in pol.policies:
+                sim_b = simulate(
+                    block,
+                    get_policy(n),
+                    fees=fee,
+                    slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+                    min_notional_usd=cfg.get("min_notional_usd", 10.0),
+                    tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
+                    step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
+                    symbol=symbol,
+                    slippage_depth=int(cfg.get("slippage_depth", 50)),
+                )
+                rets_b = sim_b["returns"]
+                eq_b = (1.0 + rets_b).cumprod()
+                metrics_block[n] = {
+                    "pnl": pnl(rets_b),
+                    "max_drawdown": max_drawdown(eq_b),
+                }
+            pol.update_weights(metrics_block)
+            print(f"Weights after block {start // block_size + 1}: {pol.weights}")
+
+        sim = simulate(
+            df,
+            pol,
+            fees=fee,
+            slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+            min_notional_usd=cfg.get("min_notional_usd", 10.0),
+            tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
+            step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
+            symbol=symbol,
+            slippage_depth=int(cfg.get("slippage_depth", 50)),
+        )
+    else:
+        pol = get_policy(args.policy)
+        sim = simulate(
+            df,
+            pol,
+            fees=fee,
+            slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+            min_notional_usd=cfg.get("min_notional_usd", 10.0),
+            tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
+            step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
+            symbol=symbol,
+            slippage_depth=int(cfg.get("slippage_depth", 50)),
+        )
     equity = sim["equity"]
     trades = sim["trades"]
     rets = sim["returns"]
@@ -77,6 +130,9 @@ def main():
     # save metrics
     with open(run_dir / "metrics.json", "w") as f:
         json.dump(metrics, f, indent=2)
+
+    # human friendly README
+    write_readme(metrics, run_dir)
 
     # save trades
     pd.DataFrame(trades).to_csv(run_dir / "trades.csv", index=False)

--- a/src/env/trading_env.py
+++ b/src/env/trading_env.py
@@ -131,22 +131,6 @@ class TradingEnv(gym.Env if 'gym' in globals() and gym is not None else object):
             except Exception:  # pragma: no cover - network issues
                 pass
 
-        self.meta = meta
-        self.symbol = symbol
-        f_cfg = cfg.get("filters", {})
-        self._tick_size = float(f_cfg.get("tickSize", 0.0))
-        self._step_size = float(f_cfg.get("stepSize", 1.0))
-        self._min_notional = float(cfg.get("min_notional_usd", 0.0))
-        self.position_size = 0.0
-        if self.meta and self.symbol:
-            try:
-                filt = self.meta.get_symbol_filters(self.symbol)
-                self._tick_size = float(filt.get("tickSize", self._tick_size))
-                self._step_size = float(filt.get("stepSize", self._step_size))
-                self._min_notional = float(filt.get("minNotional", self._min_notional))
-            except Exception:  # pragma: no cover - network issues
-                pass
-
         # environment timing and trade limits ----------------------------
         self.step_seconds = float(cfg.get("step_seconds", 60))
         self.max_trades_per_window = max_trades_per_window

--- a/src/policies/hybrid.py
+++ b/src/policies/hybrid.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+import numpy as np
+import os
+import re
+
+# Optional import for LLM assistance
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - dependency may be missing
+    openai = None  # type: ignore
+
+
+class HybridPolicy:
+    """Blend multiple policies with adaptive weights.
+
+    Parameters
+    ----------
+    policies : Dict[str, Any]
+        Mapping from policy name to policy instance. Each policy must expose an
+        ``act`` method compatible with the simulator.
+    initial_weights : Dict[str, float]
+        Starting weights for each policy. Missing entries default to uniform
+        values.
+    """
+
+    def __init__(self, policies: Dict[str, Any], initial_weights: Dict[str, float]):
+        self.policies = policies
+        if not policies:
+            raise ValueError("At least one policy is required")
+        n = len(policies)
+        # normalise weights and ensure every policy has an entry
+        weights = np.array([initial_weights.get(k, 1.0 / n) for k in policies], dtype=float)
+        weights /= weights.sum()
+        self.weights = {k: float(w) for k, w in zip(policies, weights)}
+        # store history for analysis/regularisation
+        self.metrics_history: list[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    def act(self, obs: np.ndarray) -> int:
+        """Return an action using the current weight mixture.
+
+        The policy index is sampled according to ``self.weights`` and the
+        underlying policy's ``act`` method is invoked. If the wrapped policy
+        returns ``(action, ...)`` only the first element is used.
+        """
+
+        names = list(self.policies)
+        probs = np.array([self.weights[n] for n in names], dtype=float)
+        probs /= probs.sum()
+        chosen = np.random.choice(names, p=probs)
+        res = self.policies[chosen].act(obs)
+        if isinstance(res, tuple):
+            return int(res[0])
+        return int(res)
+
+    # ------------------------------------------------------------------
+    def _heuristic_weights(self, metrics: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+        """Simple heuristic: favour higher PnL and lower drawdown."""
+
+        scores = {}
+        for name, m in metrics.items():
+            pnl = float(m.get("pnl", 0.0))
+            dd = abs(float(m.get("max_drawdown", 0.0)))
+            scores[name] = pnl - 0.5 * dd  # penalise drawdown
+        vals = np.array([scores[n] for n in self.policies], dtype=float)
+        vals -= vals.min()
+        vals += 1e-6  # keep positive
+        vals /= vals.sum()
+        return {k: float(v) for k, v in zip(self.policies, vals)}
+
+    def update_weights(self, metrics: Dict[str, Dict[str, float]]) -> None:
+        """Update mixture weights based on recent performance metrics.
+
+        ``metrics`` should map policy names to dictionaries containing at least
+        ``pnl`` and ``max_drawdown``.  A simple exponentially smoothed update is
+        applied to avoid oscillations.  When ``OPENAI_API_KEY`` is available,
+        the metrics summary is sent to an LLM which may return suggested
+        weights.  Any failure in the LLM call gracefully falls back to the
+        heuristic update.
+        """
+
+        self.metrics_history.append(metrics)
+        target = None
+
+        if openai is not None and os.getenv("OPENAI_API_KEY"):
+            try:  # pragma: no cover - network interaction
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+                summary = ", ".join(
+                    f"{k}: pnl={v.get('pnl',0):.4f} dd={v.get('max_drawdown',0):.4f}"
+                    for k, v in metrics.items()
+                )
+                prompt = (
+                    "Sugerir pesos normalizados para las políticas dada la siguiente "
+                    f"info: {summary}. Responde solo una lista de números "
+                    "separados por comas."
+                )
+                resp = openai.ChatCompletion.create(  # type: ignore
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=30,
+                )
+                text = resp["choices"][0]["message"]["content"]
+                nums = [float(x) for x in re.findall(r"[-+]?[0-9]*\.?[0-9]+", text)]
+                if len(nums) == len(self.policies):
+                    target = {k: max(0.0, n) for k, n in zip(self.policies, nums)}
+            except Exception:
+                target = None
+
+        if target is None:
+            target = self._heuristic_weights(metrics)
+
+        # normalise and apply exponential moving average to smooth updates
+        arr = np.array([target[k] for k in self.policies], dtype=float)
+        arr /= arr.sum()
+        beta = 0.3  # update rate
+        for k, new_w in zip(self.policies, arr):
+            self.weights[k] = float((1 - beta) * self.weights[k] + beta * new_w)
+

--- a/src/reports/human_friendly.py
+++ b/src/reports/human_friendly.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Render evaluation metrics in a human friendly way.
+
+This module provides two helpers:
+- ``render_panel`` draws a Streamlit summary panel with tooltips.
+- ``write_readme`` persists a short Markdown summary for the run.
+"""
+
+from pathlib import Path
+from typing import Mapping
+
+
+def _pnl_face(pnl: float) -> str:
+    """Return an emoji representing profit sentiment."""
+    if pnl > 0.05:
+        return "\U0001F642"  # 🙂
+    if pnl > -0.05:
+        return "\U0001F610"  # 😐
+    return "\U0001F641"      # 🙁
+
+
+def _dd_light(drawdown: float) -> str:
+    """Return a traffic light emoji for max drawdown."""
+    if drawdown < 0.05:
+        return "\U0001F7E2"  # green circle
+    if drawdown < 0.15:
+        return "\U0001F7E1"  # yellow circle
+    return "\U0001F534"      # red circle
+
+
+def write_readme(metrics: Mapping[str, float], run_dir: Path) -> None:
+    """Write a short Markdown summary with friendly names."""
+    run_dir = Path(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    pnl = metrics.get("pnl", 0.0)
+    dd = metrics.get("max_drawdown", 0.0)
+    sharpe = metrics.get("sharpe", 0.0)
+    hit = metrics.get("hit_ratio", 0.0)
+    turn = metrics.get("turnover", 0.0)
+
+    lines = [
+        "# Resumen amigable",
+        "",
+        f"- Ganancia total: {pnl*100:.2f}% {_pnl_face(pnl)}",
+        f"- Caída máxima: {dd*100:.2f}% {_dd_light(dd)}",
+        f"- Consistencia: {sharpe:.2f} (estabilidad de resultados)",
+        f"- Acierto: {hit*100:.2f}% (de cada 10, acierta {hit*10:.1f})",
+        f"- Actividad: {turn:.2f} (cuánto mueve el bot)",
+    ]
+    (run_dir / "README.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def render_panel(metrics: Mapping[str, float]) -> None:
+    """Render a Streamlit panel summarising metrics with tooltips."""
+    import streamlit as st
+
+    pnl = metrics.get("pnl", 0.0)
+    dd = metrics.get("max_drawdown", 0.0)
+    sharpe = metrics.get("sharpe", 0.0)
+    hit = metrics.get("hit_ratio", 0.0)
+    turn = metrics.get("turnover", 0.0)
+
+    st.subheader("Resumen amigable")
+    c1, c2 = st.columns(2)
+    with c1:
+        st.metric(
+            "Ganancia total",
+            f"{pnl*100:.2f}% {_pnl_face(pnl)}",
+            help="Rentabilidad total del periodo",
+        )
+        st.metric(
+            "Caída máxima",
+            f"{dd*100:.2f}% {_dd_light(dd)}",
+            help="Pérdida máxima desde un pico; color indica riesgo",
+        )
+        st.metric(
+            "Consistencia",
+            f"{sharpe:.2f}",
+            help="Qué tan estables son los resultados; mayor es mejor",
+        )
+    with c2:
+        st.metric(
+            "Acierto",
+            f"{hit*100:.2f}%",
+            help=f"de cada 10, acierta {hit*10:.1f}",
+        )
+        st.metric(
+            "Actividad",
+            f"{turn:.2f}",
+            help="Cuánto opera el bot",
+        )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -3,7 +3,8 @@ from datetime import datetime
 import streamlit as st
 
 from src.utils.config import load_config
-from src.utils.paths import ensure_dirs_exist, get_raw_dir
+from src.utils.paths import ensure_dirs_exist, get_raw_dir, get_reports_dir
+from src.reports.human_friendly import render_panel
 from src.data.ccxt_loader import get_exchange, fetch_ohlcv, save_history
 from src.data.volatility_windows import find_high_activity_windows
 from src.data.symbol_discovery import discover_symbols
@@ -322,7 +323,24 @@ if st.button("📈 Evaluar"):
     st.info("Ejecutando: " + " ".join(cmd))
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)
-        st.code(res.stdout or "", language="bash")
+        logs = res.stdout or ""
+        if logs:
+            st.expander("Logs").code(logs, language="bash")
+
+        reports_root = get_reports_dir(cfg)
+        run_dirs = sorted(reports_root.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if run_dirs:
+            latest = run_dirs[0]
+            try:
+                with open(latest / "metrics.json") as f:
+                    metrics = json.load(f)
+                render_panel(metrics)
+                st.caption(f"Resumen guardado en {latest}")
+            except Exception as err:
+                st.error(f"No se pudo leer métricas: {err}")
+        else:
+            st.warning("No hay reportes disponibles")
+
         if res.stderr:
             st.error(res.stderr)
     except Exception as e:


### PR DESCRIPTION
## Summary
- add `human_friendly` reporter to generate README summaries and a Streamlit panel with friendly metric names and emojis
- invoke renderer from evaluation to save the Markdown report and from the UI to replace raw metric output with tooltip-rich panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab2b11dc8328a094f7747557ef64