### PR TITLE
Ensure OHLCV availability with download helper and dynamic slippage filters

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,6 +7,7 @@ fees:
   maker: 0.001
 slippage_multiplier: 1.0  # safety factor on estimated slippage
 slippage_depth: 50
+slippage_static: 0.001
 min_notional_usd: 10.0
 filters:
   tickSize: 0.01

--- a/src/backtest/evaluate.py
+++ b/src/backtest/evaluate.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 import argparse
+from pathlib import Path
 import pandas as pd
 from .simulator import simulate
 from ..policies.router import get_policy
 from ..policies.hybrid import HybridPolicy
 from ..utils.data_io import load_table
 from ..utils.config import load_config
-from ..utils.paths import get_raw_dir, get_reports_dir, ensure_dirs_exist
+from ..utils.paths import get_raw_dir, get_reports_dir, ensure_dirs_exist, raw_parquet_path
 from ..reports.human_friendly import write_readme
 from ..utils.device import get_device, set_cpu_threads
+from ..data.ensure import ensure_ohlcv
 
 from .metrics import pnl, sharpe, sortino, max_drawdown, hit_ratio, turnover
 import json
@@ -30,13 +32,18 @@ def main():
     timeframe = cfg.get("timeframe", "1m")
 
     if args.data:
-        df = load_table(args.data)
+        df = load_table(Path(args.data).as_posix())
     else:
-        path = data_root / exchange / symbol.replace("/","-") / f"{timeframe}.parquet"
+        path = raw_parquet_path(exchange, symbol, timeframe, data_root)
+        if not path.exists():
+            try:
+                ensure_ohlcv(exchange, symbol, timeframe, root=data_root)
+            except Exception as exc:
+                print(f"ensure_ohlcv failed: {exc}")
         if not path.exists():
             alt = path.with_suffix(".csv")
             path = alt if alt.exists() else path
-        df = load_table(path)
+        df = load_table(path.as_posix())
 
     fee = cfg.get("fees", {}).get("taker", 0.001)
     print(f"Using fees: {cfg.get('fees', {})}")
@@ -78,6 +85,7 @@ def main():
                     get_policy(n, **_pk(n)),
                     fees=fee,
                     slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+                    slippage_static=cfg.get("slippage_static", 0.0),
                     min_notional_usd=cfg.get("min_notional_usd", 10.0),
                     tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
                     step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
@@ -98,6 +106,7 @@ def main():
             pol,
             fees=fee,
             slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+            slippage_static=cfg.get("slippage_static", 0.0),
             min_notional_usd=cfg.get("min_notional_usd", 10.0),
             tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
             step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
@@ -111,6 +120,7 @@ def main():
             pol,
             fees=fee,
             slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+            slippage_static=cfg.get("slippage_static", 0.0),
             min_notional_usd=cfg.get("min_notional_usd", 10.0),
             tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
             step_size=cfg.get("filters", {}).get("stepSize", 0.0001),

--- a/src/backtest/simulator.py
+++ b/src/backtest/simulator.py
@@ -6,8 +6,13 @@ import numpy as np
 import pandas as pd
 import logging
 
-from ..utils.risk import passes_min_notional, round_to_step, round_to_tick
+from ..utils.risk import (
+    passes_min_notional,
+    apply_qty_step,
+    apply_price_tick,
+)
 from ..risk.slippage import estimate_slippage
+from ..exchange.binance_meta import BinanceMeta
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +28,8 @@ def simulate(
     step_size: float = 0.0001,
     symbol: str = "BTC/USDT",
     slippage_depth: int = 50,
+    slippage_static: float = 0.0,
+    meta: BinanceMeta | None = None,
 ) -> Dict[str, Any]:
     """Run a minimalistic trading simulation.
 
@@ -36,7 +43,22 @@ def simulate(
     peak = 0.0
     trades: list[Dict[str, Any]] = []
 
-    qty = round_to_step(1.0, step_size)
+    if meta is None:
+        try:
+            meta = BinanceMeta()
+        except Exception as exc:  # pragma: no cover - network issues
+            logger.warning("meta_fallback reason=%s", exc)
+            meta = None
+    if meta is not None:
+        try:
+            filt = meta.get_symbol_filters(symbol)
+            tick_size = float(filt.get("tickSize", tick_size))
+            step_size = float(filt.get("stepSize", step_size))
+            min_notional_usd = float(filt.get("minNotional", min_notional_usd))
+        except Exception as exc:  # pragma: no cover - network issues
+            logger.warning("filter_fallback reason=%s", exc)
+
+    qty = apply_qty_step(1.0, step_size)
 
     for i in range(len(price_df)):
         row = price_df.iloc[i]
@@ -52,27 +74,76 @@ def simulate(
         if action == 1 and position == 0:
             notional = px * qty
             recent = price_df["close"].iloc[max(0, i - 60) : i + 1]
-            slip = estimate_slippage(symbol, notional, "buy", depth=slippage_depth, prices=recent) * slippage_multiplier
-            exec_px = round_to_tick(px * (1 + slip), tick_size)
-            logger.info("sim_open i=%s slippage=%.6f", i, slip)
+            try:
+                slip = estimate_slippage(
+                    symbol, notional, "buy", depth=slippage_depth, prices=recent
+                ) * slippage_multiplier
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.warning("slippage_static reason=%s", exc)
+                slip = slippage_static * slippage_multiplier
+            exec_px = apply_price_tick(px * (1 + slip), tick_size)
+            value = exec_px * qty
+            logger.info(
+                "sim_open i=%s price=%.8f qty=%.8f value=%.8f slippage=%.6f tick=%.6f step=%.6f minNotional=%.6f",
+                i,
+                exec_px,
+                qty,
+                value,
+                slip,
+                tick_size,
+                step_size,
+                min_notional_usd,
+            )
             if passes_min_notional(exec_px, qty, min_notional_usd):
                 entry = exec_px
                 peak = entry
                 position = 1
+            else:
+                logger.info(
+                    "Trade blocked: value %.8f < minNotional %.8f",
+                    value,
+                    min_notional_usd,
+                )
         elif action == 2 and position == 1:
             notional = px * qty
             recent = price_df["close"].iloc[max(0, i - 60) : i + 1]
-            slip = estimate_slippage(symbol, notional, "sell", depth=slippage_depth, prices=recent) * slippage_multiplier
-            exit_px = round_to_tick(px * (1 - slip), tick_size)
-            logger.info("sim_close i=%s slippage=%.6f", i, slip)
-            cost = entry * qty * (1 + fees)
-            proceeds = exit_px * qty * (1 - fees)
-            pnl = (proceeds - cost) / cost
-            equity *= 1.0 + pnl
-            trades.append({"i": i, "entry": entry, "exit": exit_px, "pnl": pnl, "equity": equity})
-            position = 0
-            entry = 0.0
-            peak = 0.0
+            try:
+                slip = estimate_slippage(
+                    symbol, notional, "sell", depth=slippage_depth, prices=recent
+                ) * slippage_multiplier
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.warning("slippage_static reason=%s", exc)
+                slip = slippage_static * slippage_multiplier
+            exit_px = apply_price_tick(px * (1 - slip), tick_size)
+            value = exit_px * qty
+            logger.info(
+                "sim_close i=%s price=%.8f qty=%.8f value=%.8f slippage=%.6f tick=%.6f step=%.6f minNotional=%.6f",
+                i,
+                exit_px,
+                qty,
+                value,
+                slip,
+                tick_size,
+                step_size,
+                min_notional_usd,
+            )
+            if passes_min_notional(exit_px, qty, min_notional_usd):
+                cost = entry * qty * (1 + fees)
+                proceeds = exit_px * qty * (1 - fees)
+                pnl = (proceeds - cost) / cost
+                equity *= 1.0 + pnl
+                trades.append(
+                    {"i": i, "entry": entry, "exit": exit_px, "pnl": pnl, "equity": equity}
+                )
+                position = 0
+                entry = 0.0
+                peak = 0.0
+            else:
+                logger.info(
+                    "Trade blocked: value %.8f < minNotional %.8f",
+                    value,
+                    min_notional_usd,
+                )
 
         if position == 1:
             peak = max(peak, px)

--- a/src/data/ensure.py
+++ b/src/data/ensure.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Helpers to ensure OHLCV data availability."""
+
+from datetime import datetime, timedelta
+import time
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from ..utils.paths import raw_parquet_path
+
+
+def ensure_ohlcv(
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    *,
+    hours: int = 24,
+    root: Optional[Path | str] = None,
+) -> Path:
+    """Ensure a parquet file with OHLCV data exists and return its path.
+
+    If the file is missing the function attempts to download the minimal
+    required range using ``ccxt``.  A simple exponential backoff handles
+    rate limits.  When downloading fails a ``RuntimeError`` is raised.
+    """
+
+    path = raw_parquet_path(exchange, symbol, timeframe, root)
+    if path.exists():
+        return path
+
+    try:  # pragma: no cover - optional dependency
+        import ccxt  # type: ignore
+    except Exception as exc:  # pragma: no cover - missing optional dep
+        raise RuntimeError("ccxt is required to download data") from exc
+
+    ex_class = getattr(ccxt, exchange)
+    ex = ex_class({"enableRateLimit": True})
+
+    since = int((datetime.utcnow() - timedelta(hours=hours)).timestamp() * 1000)
+    tf_ms = ex.parse_timeframe(timeframe) * 1000
+    now_ms = int(datetime.utcnow().timestamp() * 1000)
+
+    rows: list[list[float]] = []
+    while since < now_ms:
+        for attempt in range(5):
+            try:
+                batch = ex.fetch_ohlcv(symbol, timeframe=timeframe, since=since)
+                break
+            except ccxt.RateLimitExceeded:  # pragma: no cover - network
+                time.sleep(2 ** attempt)
+        else:  # pragma: no cover - network
+            raise RuntimeError("rate limit exceeded fetching OHLCV")
+
+        if not batch:
+            break
+        rows.extend(batch)
+        since = batch[-1][0] + tf_ms
+
+    if not rows:
+        raise RuntimeError("no OHLCV data downloaded")
+
+    df = pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
+    df["exchange"] = exchange
+    df["symbol"] = symbol
+    df["timeframe"] = timeframe
+    df["source"] = "ccxt"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path)
+    return path

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -30,3 +30,24 @@ def ensure_dirs_exist(cfg: Mapping[str, Any]) -> None:
     """Create common project directories if they do not already exist."""
     for directory in [get_raw_dir(cfg), get_reports_dir(cfg), get_checkpoints_dir(cfg)]:
         directory.mkdir(parents=True, exist_ok=True)
+
+
+def symbol_to_dir(symbol: str) -> str:
+    """Return the on-disk representation for a trading pair.
+
+    ``"ETH/USDT"`` -> ``"ETH-USDT"``
+    """
+
+    return symbol.replace("/", "-")
+
+
+def raw_parquet_path(
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    root: Path | str | None = None,
+) -> Path:
+    """Return the path to the raw OHLCV parquet file."""
+
+    base = Path(root) if root else Path("data/raw")
+    return base / exchange / symbol_to_dir(symbol) / f"{timeframe}.parquet"

--- a/tests/test_auto_utils.py
+++ b/tests/test_auto_utils.py
@@ -1,0 +1,16 @@
+from src.auto import choose_algo, tune
+
+
+def test_choose_algo_hybrid():
+    stats = {"ppo_sharpe": 1.6, "dqn_sharpe": 1.0, "ppo_maxdd": 0.2, "dqn_maxdd": 0.1}
+    env_caps = {"obs_type": "continuous", "action_type": "discrete", "state_space": 100}
+    res = choose_algo(stats, env_caps)
+    assert res["algo"] == "hybrid"
+    assert "PPO" in res["reason"]
+
+
+def test_tune_basic_and_hybrid():
+    cfg = tune("ppo", None, None)
+    assert {"learning_rate", "batch_size", "n_steps"} <= set(cfg)
+    cfg_h = tune("hybrid", None, None)
+    assert "ppo" in cfg_h and "dqn" in cfg_h

--- a/tests/test_env_slippage.py
+++ b/tests/test_env_slippage.py
@@ -11,7 +11,11 @@ def test_env_logs_slippage(monkeypatch, caplog):
         "low": [100, 101, 101],
         "close": [100, 101, 101],
     })
-    cfg = {"fees": {"taker": 0.0}, "filters": {"tickSize": 0.01, "stepSize": 1.0}, "slippage_multiplier": 2.0}
+    cfg = {
+        "fees": {"taker": 0.0},
+        "filters": {"tickSize": 0.01, "stepSize": 1.0},
+        "slippage_multiplier": 2.0,
+    }
 
     def fake_slippage(symbol, notional, side, depth=50, prices=None, exchange=None):
         return 0.01
@@ -21,4 +25,35 @@ def test_env_logs_slippage(monkeypatch, caplog):
 
     with caplog.at_level(logging.INFO):
         env.step(1)  # open
-    assert any("slippage=0.020000" in r.message for r in caplog.records)
+    assert any(
+        "slippage=0.020000" in r.message
+        and "tick=0.010000" in r.message
+        and "step=1.000000" in r.message
+        and "minNotional=0.000000" in r.message
+        for r in caplog.records
+    )
+
+
+def test_env_slippage_fallback(monkeypatch, caplog):
+    df = pd.DataFrame({
+        "open": [100, 101],
+        "high": [100, 101],
+        "low": [100, 101],
+        "close": [100, 101],
+    })
+    cfg = {
+        "fees": {"taker": 0.0},
+        "filters": {"tickSize": 0.01, "stepSize": 1.0},
+        "slippage_multiplier": 1.0,
+        "slippage_static": 0.05,
+    }
+
+    def raise_slip(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.env.trading_env.estimate_slippage", raise_slip)
+    env = TradingEnv(df, cfg=cfg, symbol="BTC/USDT")
+
+    with caplog.at_level(logging.INFO):
+        env.step(1)
+    assert any("slippage=0.050000" in r.message for r in caplog.records)

--- a/tests/test_human_readme.py
+++ b/tests/test_human_readme.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from src.reports.human_friendly import write_readme
+
+def test_write_readme_creates_file(tmp_path: Path):
+    metrics = {
+        "pnl": 0.1,
+        "max_drawdown": 0.05,
+        "sharpe": 1.2,
+        "hit_ratio": 0.6,
+        "turnover": 2.0,
+    }
+    write_readme(metrics, tmp_path)
+    readme = tmp_path / "README.md"
+    assert readme.exists()
+    content = readme.read_text(encoding="utf-8")
+    assert "Ganancia total" in content
+    assert "Caída máxima" in content
+    assert "Consistencia" in content

--- a/tests/test_hybrid_policy_block.py
+++ b/tests/test_hybrid_policy_block.py
@@ -1,0 +1,22 @@
+from src.policies.hybrid import HybridPolicy
+
+
+class Dummy:
+    def __init__(self, val: int):
+        self.val = val
+
+    def act(self, obs):
+        return self.val
+
+
+def test_record_trade_updates_weights():
+    pol = HybridPolicy({"a": Dummy(0), "b": Dummy(1)}, {"a": 0.5, "b": 0.5}, block_size=2)
+    m = {
+        "a": {"pnl": 1.0, "max_drawdown": 0.1},
+        "b": {"pnl": 0.0, "max_drawdown": 0.2},
+    }
+    pol.record_trade(m)
+    before = pol.weights.copy()
+    pol.record_trade(m)
+    assert pol.weights["a"] > pol.weights["b"]
+    assert pol.weights != before

--- a/tests/test_simulator_filters.py
+++ b/tests/test_simulator_filters.py
@@ -1,0 +1,54 @@
+import logging
+import pandas as pd
+
+from src.backtest.simulator import simulate
+
+
+class DummyPolicy:
+    def __init__(self):
+        self.calls = 0
+    def act(self, obs):
+        self.calls += 1
+        if self.calls == 1:
+            return 1  # open
+        if self.calls == 2:
+            return 2  # close
+        return 0
+
+
+class DummyMeta:
+    def get_symbol_filters(self, symbol: str):
+        return {"tickSize": 0.1, "stepSize": 0.5, "minNotional": 50.0}
+
+
+def test_simulator_logs_filters(monkeypatch, caplog):
+    df = pd.DataFrame({"close": [100.0, 101.0]})
+    monkeypatch.setattr(
+        "src.backtest.simulator.estimate_slippage", lambda *a, **k: 0.01
+    )
+    pol = DummyPolicy()
+    meta = DummyMeta()
+    with caplog.at_level(logging.INFO):
+        sim = simulate(df, pol, fees=0.0, symbol="BTC/USDT", meta=meta)
+    assert len(sim["trades"]) == 1
+    assert any(
+        "slippage=0.010000" in r.message
+        and "tick=0.100000" in r.message
+        and "step=0.500000" in r.message
+        and "minNotional=50.000000" in r.message
+        for r in caplog.records
+    )
+
+
+def test_simulator_blocks_min_notional(monkeypatch):
+    df = pd.DataFrame({"close": [1.0, 1.0]})
+    class MetaHigh:
+        def get_symbol_filters(self, symbol: str):
+            return {"tickSize": 0.1, "stepSize": 0.1, "minNotional": 10.0}
+    pol = DummyPolicy()
+    meta = MetaHigh()
+    monkeypatch.setattr(
+        "src.backtest.simulator.estimate_slippage", lambda *a, **k: 0.0
+    )
+    sim = simulate(df, pol, fees=0.0, symbol="BTC/USDT", meta=meta)
+    assert sim["trades"] == []


### PR DESCRIPTION
## Summary
- add utilities to map symbols and build raw parquet paths
- implement `ensure_ohlcv` to download missing OHLCV data with backoff
- validate trades using Binance filters and estimate slippage with configurable fallback
- render metrics in a human-friendly panel with traffic-light cues and save a README summary for each run
- auto-select algorithms with minimal hyperparameter knobs and provide an explanation panel
- introduce an adaptive hybrid policy that updates weights every N trades

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d2d1944c832899483066b012d462