### PR TITLE
Ensure OHLCV availability with download helper and dynamic slippage filters

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,6 +7,7 @@ fees:
   maker: 0.001
 slippage_multiplier: 1.0  # safety factor on estimated slippage
 slippage_depth: 50
+slippage_static: 0.001
 min_notional_usd: 10.0
 filters:
   tickSize: 0.01

--- a/src/backtest/evaluate.py
+++ b/src/backtest/evaluate.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 import argparse
+from pathlib import Path
 import pandas as pd
 from .simulator import simulate
 from ..policies.router import get_policy
 from ..policies.hybrid import HybridPolicy
 from ..utils.data_io import load_table
 from ..utils.config import load_config
-from ..utils.paths import get_raw_dir, get_reports_dir, ensure_dirs_exist
+from ..utils.paths import get_raw_dir, get_reports_dir, ensure_dirs_exist, raw_parquet_path
 from ..reports.human_friendly import write_readme
 from ..utils.device import get_device, set_cpu_threads
+from ..data.ensure import ensure_ohlcv
 
 from .metrics import pnl, sharpe, sortino, max_drawdown, hit_ratio, turnover
 import json
@@ -30,13 +32,18 @@ def main():
     timeframe = cfg.get("timeframe", "1m")
 
     if args.data:
-        df = load_table(args.data)
+        df = load_table(Path(args.data).as_posix())
     else:
-        path = data_root / exchange / symbol.replace("/","-") / f"{timeframe}.parquet"
+        path = raw_parquet_path(exchange, symbol, timeframe, data_root)
+        if not path.exists():
+            try:
+                ensure_ohlcv(exchange, symbol, timeframe, root=data_root)
+            except Exception as exc:
+                print(f"ensure_ohlcv failed: {exc}")
         if not path.exists():
             alt = path.with_suffix(".csv")
             path = alt if alt.exists() else path
-        df = load_table(path)
+        df = load_table(path.as_posix())
 
     fee = cfg.get("fees", {}).get("taker", 0.001)
     print(f"Using fees: {cfg.get('fees', {})}")
@@ -78,6 +85,7 @@ def main():
                     get_policy(n, **_pk(n)),
                     fees=fee,
                     slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+                    slippage_static=cfg.get("slippage_static", 0.0),
                     min_notional_usd=cfg.get("min_notional_usd", 10.0),
                     tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
                     step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
@@ -98,6 +106,7 @@ def main():
             pol,
             fees=fee,
             slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+            slippage_static=cfg.get("slippage_static", 0.0),
             min_notional_usd=cfg.get("min_notional_usd", 10.0),
             tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
             step_size=cfg.get("filters", {}).get("stepSize", 0.0001),
@@ -111,6 +120,7 @@ def main():
             pol,
             fees=fee,
             slippage_multiplier=cfg.get("slippage_multiplier", 1.0),
+            slippage_static=cfg.get("slippage_static", 0.0),
             min_notional_usd=cfg.get("min_notional_usd", 10.0),
             tick_size=cfg.get("filters", {}).get("tickSize", 0.01),
             step_size=cfg.get("filters", {}).get("stepSize", 0.0001),

--- a/src/backtest/simulator.py
+++ b/src/backtest/simulator.py
@@ -6,8 +6,13 @@ import numpy as np
 import pandas as pd
 import logging
 
-from ..utils.risk import passes_min_notional, round_to_step, round_to_tick
+from ..utils.risk import (
+    passes_min_notional,
+    apply_qty_step,
+    apply_price_tick,
+)
 from ..risk.slippage import estimate_slippage
+from ..exchange.binance_meta import BinanceMeta
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +28,8 @@ def simulate(
     step_size: float = 0.0001,
     symbol: str = "BTC/USDT",
     slippage_depth: int = 50,
+    slippage_static: float = 0.0,
+    meta: BinanceMeta | None = None,
 ) -> Dict[str, Any]:
     """Run a minimalistic trading simulation.
 
@@ -36,7 +43,22 @@ def simulate(
     peak = 0.0
     trades: list[Dict[str, Any]] = []
 
-    qty = round_to_step(1.0, step_size)
+    if meta is None:
+        try:
+            meta = BinanceMeta()
+        except Exception as exc:  # pragma: no cover - network issues
+            logger.warning("meta_fallback reason=%s", exc)
+            meta = None
+    if meta is not None:
+        try:
+            filt = meta.get_symbol_filters(symbol)
+            tick_size = float(filt.get("tickSize", tick_size))
+            step_size = float(filt.get("stepSize", step_size))
+            min_notional_usd = float(filt.get("minNotional", min_notional_usd))
+        except Exception as exc:  # pragma: no cover - network issues
+            logger.warning("filter_fallback reason=%s", exc)
+
+    qty = apply_qty_step(1.0, step_size)
 
     for i in range(len(price_df)):
         row = price_df.iloc[i]
@@ -52,27 +74,76 @@ def simulate(
         if action == 1 and position == 0:
             notional = px * qty
             recent = price_df["close"].iloc[max(0, i - 60) : i + 1]
-            slip = estimate_slippage(symbol, notional, "buy", depth=slippage_depth, prices=recent) * slippage_multiplier
-            exec_px = round_to_tick(px * (1 + slip), tick_size)
-            logger.info("sim_open i=%s slippage=%.6f", i, slip)
+            try:
+                slip = estimate_slippage(
+                    symbol, notional, "buy", depth=slippage_depth, prices=recent
+                ) * slippage_multiplier
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.warning("slippage_static reason=%s", exc)
+                slip = slippage_static * slippage_multiplier
+            exec_px = apply_price_tick(px * (1 + slip), tick_size)
+            value = exec_px * qty
+            logger.info(
+                "sim_open i=%s price=%.8f qty=%.8f value=%.8f slippage=%.6f tick=%.6f step=%.6f minNotional=%.6f",
+                i,
+                exec_px,
+                qty,
+                value,
+                slip,
+                tick_size,
+                step_size,
+                min_notional_usd,
+            )
             if passes_min_notional(exec_px, qty, min_notional_usd):
                 entry = exec_px
                 peak = entry
                 position = 1
+            else:
+                logger.info(
+                    "Trade blocked: value %.8f < minNotional %.8f",
+                    value,
+                    min_notional_usd,
+                )
         elif action == 2 and position == 1:
             notional = px * qty
             recent = price_df["close"].iloc[max(0, i - 60) : i + 1]
-            slip = estimate_slippage(symbol, notional, "sell", depth=slippage_depth, prices=recent) * slippage_multiplier
-            exit_px = round_to_tick(px * (1 - slip), tick_size)
-            logger.info("sim_close i=%s slippage=%.6f", i, slip)
-            cost = entry * qty * (1 + fees)
-            proceeds = exit_px * qty * (1 - fees)
-            pnl = (proceeds - cost) / cost
-            equity *= 1.0 + pnl
-            trades.append({"i": i, "entry": entry, "exit": exit_px, "pnl": pnl, "equity": equity})
-            position = 0
-            entry = 0.0
-            peak = 0.0
+            try:
+                slip = estimate_slippage(
+                    symbol, notional, "sell", depth=slippage_depth, prices=recent
+                ) * slippage_multiplier
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.warning("slippage_static reason=%s", exc)
+                slip = slippage_static * slippage_multiplier
+            exit_px = apply_price_tick(px * (1 - slip), tick_size)
+            value = exit_px * qty
+            logger.info(
+                "sim_close i=%s price=%.8f qty=%.8f value=%.8f slippage=%.6f tick=%.6f step=%.6f minNotional=%.6f",
+                i,
+                exit_px,
+                qty,
+                value,
+                slip,
+                tick_size,
+                step_size,
+                min_notional_usd,
+            )
+            if passes_min_notional(exit_px, qty, min_notional_usd):
+                cost = entry * qty * (1 + fees)
+                proceeds = exit_px * qty * (1 - fees)
+                pnl = (proceeds - cost) / cost
+                equity *= 1.0 + pnl
+                trades.append(
+                    {"i": i, "entry": entry, "exit": exit_px, "pnl": pnl, "equity": equity}
+                )
+                position = 0
+                entry = 0.0
+                peak = 0.0
+            else:
+                logger.info(
+                    "Trade blocked: value %.8f < minNotional %.8f",
+                    value,
+                    min_notional_usd,
+                )
 
         if position == 1:
             peak = max(peak, px)

--- a/src/data/ensure.py
+++ b/src/data/ensure.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Helpers to ensure OHLCV data availability."""
+
+from datetime import datetime, timedelta
+import time
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from ..utils.paths import raw_parquet_path
+
+
+def ensure_ohlcv(
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    *,
+    hours: int = 24,
+    root: Optional[Path | str] = None,
+) -> Path:
+    """Ensure a parquet file with OHLCV data exists and return its path.
+
+    If the file is missing the function attempts to download the minimal
+    required range using ``ccxt``.  A simple exponential backoff handles
+    rate limits.  When downloading fails a ``RuntimeError`` is raised.
+    """
+
+    path = raw_parquet_path(exchange, symbol, timeframe, root)
+    if path.exists():
+        return path
+
+    try:  # pragma: no cover - optional dependency
+        import ccxt  # type: ignore
+    except Exception as exc:  # pragma: no cover - missing optional dep
+        raise RuntimeError("ccxt is required to download data") from exc
+
+    ex_class = getattr(ccxt, exchange)
+    ex = ex_class({"enableRateLimit": True})
+
+    since = int((datetime.utcnow() - timedelta(hours=hours)).timestamp() * 1000)
+    tf_ms = ex.parse_timeframe(timeframe) * 1000
+    now_ms = int(datetime.utcnow().timestamp() * 1000)
+
+    rows: list[list[float]] = []
+    while since < now_ms:
+        for attempt in range(5):
+            try:
+                batch = ex.fetch_ohlcv(symbol, timeframe=timeframe, since=since)
+                break
+            except ccxt.RateLimitExceeded:  # pragma: no cover - network
+                time.sleep(2 ** attempt)
+        else:  # pragma: no cover - network
+            raise RuntimeError("rate limit exceeded fetching OHLCV")
+
+        if not batch:
+            break
+        rows.extend(batch)
+        since = batch[-1][0] + tf_ms
+
+    if not rows:
+        raise RuntimeError("no OHLCV data downloaded")
+
+    df = pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
+    df["exchange"] = exchange
+    df["symbol"] = symbol
+    df["timeframe"] = timeframe
+    df["source"] = "ccxt"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path)
+    return path

--- a/src/data/volatility_windows.py
+++ b/src/data/volatility_windows.py
@@ -1,15 +1,17 @@
+"""Helpers to select high-activity data windows."""
+
 from __future__ import annotations
 
 import logging
 import time
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Optional
 
 import pandas as pd
 
-from .ccxt_loader import get_exchange, fetch_ohlcv
+from .ccxt_loader import get_exchange
+from .ensure import ensure_ohlcv
 
 logger = logging.getLogger(__name__)
-
 
 __all__ = ["find_high_activity_windows"]
 
@@ -18,46 +20,99 @@ def _hour_floor(ts: int) -> int:
     return (ts // 3600000) * 3600000
 
 
+def _fetch_trade_counts(exchange, symbol: str, since: int, end: int) -> pd.DataFrame:
+    """Fetch trades and return hourly counts.
+
+    Network errors are ignored and result in an empty DataFrame so callers can
+    proceed using only OHLCV-based signals.
+    """
+
+    try:  # pragma: no cover - network dependent
+        trades: list[dict] = []
+        cursor = since
+        while cursor < end:
+            batch = exchange.fetch_trades(symbol, since=cursor, limit=1000)
+            if not batch:
+                break
+            trades.extend(batch)
+            cursor = batch[-1]["timestamp"] + 1
+            if len(trades) >= 10000:  # avoid huge downloads
+                break
+        if not trades:
+            return pd.DataFrame(columns=["hour", "n_trades"])
+        df = pd.DataFrame(trades)
+        df["hour"] = df["timestamp"].apply(_hour_floor)
+        return df.groupby("hour").size().reset_index(name="n_trades")
+    except Exception as exc:  # pragma: no cover - network dependent
+        logger.warning("trade_fetch_failed symbol=%s error=%s", symbol, exc)
+        return pd.DataFrame(columns=["hour", "n_trades"])
+
+
 def find_high_activity_windows(
     symbols: Iterable[str],
     timeframe_min: int,
-    lookback_years: int = 5,
-    target_hours: int = 2000,
-) -> List[Tuple[int, int]]:
-    """Return high activity windows for *symbols*.
+    *,
+    target_hours: int = 24,
+    lookback_hours: Optional[int] = None,
+    exchange: Optional[object] = None,
+) -> Tuple[List[Tuple[int, int]], int]:
+    """Return high activity windows and the lookback span used.
 
-    The function performs a lightweight scan over recent historical data,
-    scoring each hour by the standard deviation of returns plus the traded
-    volume.  The top ``target_hours`` are selected and merged into
-    contiguous windows.  The chosen windows and total hours are logged.
+    Each hour is scored by ``std(returns) + volume + number_of_trades``.  The
+    ``target_hours`` top-scoring hours are merged into contiguous windows.  If
+    ``lookback_hours`` is omitted it defaults to six times ``target_hours`` to
+    provide a pool of candidates.
     """
 
-    exchange = get_exchange()
+    ex = exchange or get_exchange()
     tf_str = f"{timeframe_min}m"
+    if lookback_hours is None:
+        lookback_hours = target_hours * 6
     end = int(time.time() * 1000)
-    lookback_ms = lookback_years * 365 * 24 * 3600 * 1000
-    since = end - lookback_ms
+    since = end - lookback_hours * 3600000
 
     frames: List[pd.DataFrame] = []
+    trade_frames: List[pd.DataFrame] = []
     for sym in symbols:
         try:
-            df = fetch_ohlcv(exchange, sym, timeframe=tf_str, since=since)
+            path = ensure_ohlcv(
+                ex.id if hasattr(ex, "id") else "binance", sym, tf_str, hours=lookback_hours
+            )
+            df = pd.read_parquet(path)
+            df = df[df["ts"] >= since]
             df["symbol"] = sym
             frames.append(df)
+
+            trade_counts = _fetch_trade_counts(ex, sym, since, end)
+            if not trade_counts.empty:
+                trade_frames.append(trade_counts)
         except Exception as exc:  # pragma: no cover - network dependent
             logger.warning("ohlcv_fetch_failed symbol=%s error=%s", sym, exc)
 
     if not frames:
         logger.warning("no_data_for_volatility_scan")
-        return []
+        return [], lookback_hours
 
     df_all = pd.concat(frames)
     df_all.sort_values("ts", inplace=True)
     df_all["ret"] = df_all.groupby("symbol")["close"].pct_change().fillna(0.0)
     df_all["hour"] = df_all["ts"].apply(_hour_floor)
 
-    grouped = df_all.groupby("hour").agg({"ret": "std", "volume": "sum"})
-    grouped["score"] = grouped["ret"].fillna(0) + grouped["volume"].fillna(0)
+    grouped = df_all.groupby("hour").agg(ret=("ret", "std"), volume=("volume", "sum"))
+    if trade_frames:
+        trades_all = pd.concat(trade_frames)
+        trades_group = trades_all.groupby("hour")["n_trades"].sum()
+        grouped = grouped.join(trades_group, how="left")
+    grouped["n_trades"] = grouped.get(
+        "n_trades", pd.Series(0, index=grouped.index)
+    ).fillna(0)
+
+    grouped["score"] = (
+        grouped["ret"].fillna(0)
+        + grouped["volume"].fillna(0)
+        + grouped["n_trades"].fillna(0)
+    )
+
     top = grouped.sort_values("score", ascending=False).head(target_hours)
 
     hours = sorted(top.index)
@@ -75,5 +130,8 @@ def find_high_activity_windows(
         windows.append((int(start), int(prev + 3600000)))
 
     total_hours = sum((e - s) // 3600000 for s, e in windows)
-    logger.info("selected_vol_windows=%s total_hours=%s", windows, total_hours)
-    return windows
+    logger.info(
+        "selected_vol_windows=%s total_hours=%s lookback_hours=%s", windows, total_hours, lookback_hours
+    )
+    return windows, lookback_hours
+

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -6,7 +6,8 @@ from src.utils.config import load_config
 from src.utils.paths import ensure_dirs_exist, get_raw_dir, get_reports_dir
 from src.reports.human_friendly import render_panel
 from src.utils.device import get_device, set_cpu_threads
-from src.data.ccxt_loader import get_exchange, fetch_ohlcv, save_history
+from src.data.ccxt_loader import get_exchange, save_history
+from src.data.ensure import ensure_ohlcv
 from src.data.volatility_windows import find_high_activity_windows
 from src.data.symbol_discovery import discover_symbols
 from src.data import (
@@ -171,94 +172,85 @@ with st.sidebar:
     )
 
     stats = cfg.get("stats", {})
-    env_caps = {"obs_type": "continuous", "action_type": "discrete", "state_space": stats.get("state_space", 100)}
+    env_caps = {
+        "obs_type": "continuous",
+        "action_type": "discrete",
+        "state_space": stats.get("state_space", 100),
+    }
     choice = choose_algo(stats, env_caps)
     algo = choice["algo"]
     cfg["algo"] = algo
-    st.success(f"Algoritmo elegido: {algo} — {choice['reason']}")
     suggested = tune(algo, stats, [])
     if algo == "hybrid":
         ppo_sug = suggested.get("ppo", {})
         dqn_sug = suggested.get("dqn", {})
-        st.subheader("Hiperparámetros críticos PPO")
-        ppo_lr = st.number_input(
-            "Velocidad de aprendizaje (qué tan rápido aprende)",
-            value=float(ppo_sug.get("learning_rate", 3e-4)),
-            format="%.6f",
-            help=f"Sugerido {ppo_sug.get('learning_rate',3e-4):.2e}",
-            key="ppo_lr",
-        )
-        ppo_batch = st.number_input(
-            "Tamaño de lote (cada cuántos ejemplos actualiza)",
-            value=int(ppo_sug.get("batch_size", 64)),
-            help=f"Sugerido {ppo_sug.get('batch_size',64)}",
-            key="ppo_batch",
-        )
-        ppo_steps = st.number_input(
-            "Horizonte de actualización (pasos antes de actualizar)",
-            value=int(ppo_sug.get("n_steps", 2048)),
-            help=f"Sugerido {ppo_sug.get('n_steps',2048)}",
-            key="ppo_steps",
-        )
-        st.subheader("Hiperparámetros críticos DQN")
-        dqn_lr = st.number_input(
-            "Velocidad de aprendizaje (qué tan rápido aprende) [DQN]",
-            value=float(dqn_sug.get("learning_rate", 1e-3)),
-            format="%.6f",
-            help=f"Sugerido {dqn_sug.get('learning_rate',1e-3):.2e}",
-            key="dqn_lr",
-        )
-        dqn_batch = st.number_input(
-            "Tamaño de lote (cada cuántos ejemplos actualiza) [DQN]",
-            value=int(dqn_sug.get("batch_size", 64)),
-            help=f"Sugerido {dqn_sug.get('batch_size',64)}",
-            key="dqn_batch",
-        )
-        dqn_steps = st.number_input(
-            "Horizonte de actualización (pasos antes de actualizar) [DQN]",
-            value=int(dqn_sug.get("n_steps", 1000)),
-            help=f"Sugerido {dqn_sug.get('n_steps',1000)}",
-            key="dqn_steps",
-        )
-        cfg["ppo"] = {
-            "learning_rate": ppo_lr,
-            "batch_size": int(ppo_batch),
-            "n_steps": int(ppo_steps),
-        }
-        cfg["dqn"] = {
-            "learning_rate": dqn_lr,
-            "batch_size": int(dqn_batch),
-            "target_update": int(dqn_steps),
+
+        def _avg(key: str, default: float | int) -> float:
+            p = ppo_sug.get(key)
+            d = dqn_sug.get("target_update" if key == "n_steps" else key)
+            vals = [v for v in [p, d] if v is not None]
+            return float(sum(vals) / len(vals)) if vals else float(default)
+
+        suggested_flat = {
+            "learning_rate": _avg("learning_rate", 3e-4),
+            "batch_size": int(_avg("batch_size", 64)),
+            "n_steps": int(_avg("n_steps", 2048)),
         }
     else:
-        lr = st.number_input(
-            "Velocidad de aprendizaje (qué tan rápido aprende)",
-            value=float(suggested.get("learning_rate", 3e-4)),
-            format="%.6f",
-            help=f"Sugerido {suggested.get('learning_rate',3e-4):.2e}",
-        )
-        batch = st.number_input(
-            "Tamaño de lote (cada cuántos ejemplos actualiza)",
-            value=int(suggested.get("batch_size", 64)),
-            help=f"Sugerido {suggested.get('batch_size',64)}",
-        )
-        horizon = st.number_input(
-            "Horizonte de actualización (pasos antes de actualizar)",
-            value=int(suggested.get("n_steps", 2048)),
-            help=f"Sugerido {suggested.get('n_steps',2048)}",
-        )
-        if algo == "ppo":
-            cfg["ppo"] = {
-                "learning_rate": lr,
-                "batch_size": int(batch),
-                "n_steps": int(horizon),
-            }
+        suggested_flat = {
+            "learning_rate": float(suggested.get("learning_rate", 3e-4)),
+            "batch_size": int(suggested.get("batch_size", 64)),
+            "n_steps": int(suggested.get("n_steps", suggested.get("target_update", 2048))),
+        }
+
+    lr = st.number_input(
+        "Velocidad de aprendizaje",
+        value=float(suggested_flat["learning_rate"]),
+        format="%.6f",
+        help=f"Sugerido {suggested_flat['learning_rate']:.2e}",
+    )
+    batch = st.number_input(
+        "Tamaño de lote",
+        value=int(suggested_flat["batch_size"]),
+        help=f"Sugerido {suggested_flat['batch_size']}",
+    )
+    horizon = st.number_input(
+        "Horizonte de actualización",
+        value=int(suggested_flat["n_steps"]),
+        help=f"Sugerido {suggested_flat['n_steps']}",
+    )
+    selected = {"learning_rate": lr, "batch_size": int(batch), "n_steps": int(horizon)}
+
+    if algo == "ppo":
+        cfg["ppo"] = selected
+    elif algo == "dqn":
+        cfg["dqn"] = {
+            "learning_rate": lr,
+            "batch_size": int(batch),
+            "target_update": int(horizon),
+        }
+    else:  # hybrid
+        cfg["ppo"] = selected
+        cfg["dqn"] = {
+            "learning_rate": lr,
+            "batch_size": int(batch),
+            "target_update": int(horizon),
+        }
+
+    if st.button("Explicación"):
+        st.info(f"Algoritmo elegido: {algo}")
+        st.write(choice["reason"])
+        diffs = {
+            k: (suggested_flat[k], selected[k])
+            for k in selected
+            if selected[k] != suggested_flat[k]
+        }
+        if diffs:
+            st.write("Ajustes modificados:")
+            for k, (sug, val) in diffs.items():
+                st.write(f"{k}: {sug} -> {val}")
         else:
-            cfg["dqn"] = {
-                "learning_rate": lr,
-                "batch_size": int(batch),
-                "target_update": int(horizon),
-            }
+            st.write("Se usan hiperparámetros sugeridos sin cambios.")
 
     st.header("Asistente LLM")
     llm_model = st.selectbox(
@@ -396,29 +388,43 @@ if st.button("⬇️ Descargar histórico"):
         tf_str = cfg.get("timeframe", "1m")
         timeframe_min = int(tf_str.rstrip("m"))
         st.info("Construyendo dataset con tramos de alta actividad...")
-        windows = find_high_activity_windows(selected_symbols, timeframe_min)
+        windows, lookback_h = find_high_activity_windows(
+            selected_symbols, timeframe_min
+        )
         if windows:
             st.write("Ventanas ejemplo:")
             for s, e in windows[:5]:
-                st.write(f"{datetime.fromtimestamp(s/1000, UTC)} → {datetime.fromtimestamp(e/1000, UTC)}")
-        ex = get_exchange(use_testnet=use_testnet)
-        for sym in selected_symbols:
-            parts = []
-            for s, e in windows:
-                limit = int((e - s) / (timeframe_min * 60 * 1000))
-                try:
-                    df = fetch_ohlcv(ex, sym, timeframe=tf_str, since=s, limit=limit)
-                    parts.append(df)
-                except Exception as err:
-                    st.warning(f"Fallo {sym}: {err}")
-            if parts:
-                merged = pd.concat(parts)
-                tf = merged.attrs.get("timeframe", tf_str)
-                cfg["timeframe"] = tf
-                path = save_history(merged, str(raw_dir), "binance", sym, tf)
-                st.success(f"Guardado: {path}")
+                st.write(
+                    f"{datetime.fromtimestamp(s/1000, UTC)} → {datetime.fromtimestamp(e/1000, UTC)}"
+                )
         total_hours = sum((e - s) // 3600000 for s, e in windows)
         st.info(f"Ventanas total: {total_hours}h")
+        ex = get_exchange(use_testnet=use_testnet)
+        for sym in selected_symbols:
+            try:
+                path = ensure_ohlcv(
+                    ex.id if hasattr(ex, "id") else "binance",
+                    sym,
+                    tf_str,
+                    hours=lookback_h,
+                    root=raw_dir,
+                )
+                df = pd.read_parquet(path)
+                parts = [df[(df.ts >= s) & (df.ts < e)] for s, e in windows]
+                if parts:
+                    merged = pd.concat(parts)
+                    tf = tf_str
+                    cfg["timeframe"] = tf
+                    out = save_history(
+                        merged,
+                        str(raw_dir),
+                        ex.id if hasattr(ex, "id") else "binance",
+                        sym,
+                        tf,
+                    )
+                    st.success(f"Guardado: {out}")
+            except Exception as err:
+                st.warning(f"Fallo {sym}: {err}")
     except Exception as e:
         st.error(f"Error en descarga: {e}")
 
@@ -494,8 +500,8 @@ if st.button("📈 Evaluar"):
             latest = run_dirs[0]
             try:
                 with open(latest / "metrics.json") as f:
-                    metrics = json.load(f)
-                render_panel(metrics)
+                    results = json.load(f)
+                render_panel(results)
                 st.caption(f"Resumen guardado en {latest}")
             except Exception as err:
                 st.error(f"No se pudo leer métricas: {err}")

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -30,3 +30,24 @@ def ensure_dirs_exist(cfg: Mapping[str, Any]) -> None:
     """Create common project directories if they do not already exist."""
     for directory in [get_raw_dir(cfg), get_reports_dir(cfg), get_checkpoints_dir(cfg)]:
         directory.mkdir(parents=True, exist_ok=True)
+
+
+def symbol_to_dir(symbol: str) -> str:
+    """Return the on-disk representation for a trading pair.
+
+    ``"ETH/USDT"`` -> ``"ETH-USDT"``
+    """
+
+    return symbol.replace("/", "-")
+
+
+def raw_parquet_path(
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    root: Path | str | None = None,
+) -> Path:
+    """Return the path to the raw OHLCV parquet file."""
+
+    base = Path(root) if root else Path("data/raw")
+    return base / exchange / symbol_to_dir(symbol) / f"{timeframe}.parquet"

--- a/tests/test_auto_utils.py
+++ b/tests/test_auto_utils.py
@@ -1,0 +1,16 @@
+from src.auto import choose_algo, tune
+
+
+def test_choose_algo_hybrid():
+    stats = {"ppo_sharpe": 1.6, "dqn_sharpe": 1.0, "ppo_maxdd": 0.2, "dqn_maxdd": 0.1}
+    env_caps = {"obs_type": "continuous", "action_type": "discrete", "state_space": 100}
+    res = choose_algo(stats, env_caps)
+    assert res["algo"] == "hybrid"
+    assert "PPO" in res["reason"]
+
+
+def test_tune_basic_and_hybrid():
+    cfg = tune("ppo", None, None)
+    assert {"learning_rate", "batch_size", "n_steps"} <= set(cfg)
+    cfg_h = tune("hybrid", None, None)
+    assert "ppo" in cfg_h and "dqn" in cfg_h

--- a/tests/test_env_slippage.py
+++ b/tests/test_env_slippage.py
@@ -11,7 +11,11 @@ def test_env_logs_slippage(monkeypatch, caplog):
         "low": [100, 101, 101],
         "close": [100, 101, 101],
     })
-    cfg = {"fees": {"taker": 0.0}, "filters": {"tickSize": 0.01, "stepSize": 1.0}, "slippage_multiplier": 2.0}
+    cfg = {
+        "fees": {"taker": 0.0},
+        "filters": {"tickSize": 0.01, "stepSize": 1.0},
+        "slippage_multiplier": 2.0,
+    }
 
     def fake_slippage(symbol, notional, side, depth=50, prices=None, exchange=None):
         return 0.01
@@ -21,4 +25,35 @@ def test_env_logs_slippage(monkeypatch, caplog):
 
     with caplog.at_level(logging.INFO):
         env.step(1)  # open
-    assert any("slippage=0.020000" in r.message for r in caplog.records)
+    assert any(
+        "slippage=0.020000" in r.message
+        and "tick=0.010000" in r.message
+        and "step=1.000000" in r.message
+        and "minNotional=0.000000" in r.message
+        for r in caplog.records
+    )
+
+
+def test_env_slippage_fallback(monkeypatch, caplog):
+    df = pd.DataFrame({
+        "open": [100, 101],
+        "high": [100, 101],
+        "low": [100, 101],
+        "close": [100, 101],
+    })
+    cfg = {
+        "fees": {"taker": 0.0},
+        "filters": {"tickSize": 0.01, "stepSize": 1.0},
+        "slippage_multiplier": 1.0,
+        "slippage_static": 0.05,
+    }
+
+    def raise_slip(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.env.trading_env.estimate_slippage", raise_slip)
+    env = TradingEnv(df, cfg=cfg, symbol="BTC/USDT")
+
+    with caplog.at_level(logging.INFO):
+        env.step(1)
+    assert any("slippage=0.050000" in r.message for r in caplog.records)

--- a/tests/test_human_readme.py
+++ b/tests/test_human_readme.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from src.reports.human_friendly import write_readme
+
+def test_write_readme_creates_file(tmp_path: Path):
+    metrics = {
+        "pnl": 0.1,
+        "max_drawdown": 0.05,
+        "sharpe": 1.2,
+        "hit_ratio": 0.6,
+        "turnover": 2.0,
+    }
+    write_readme(metrics, tmp_path)
+    readme = tmp_path / "README.md"
+    assert readme.exists()
+    content = readme.read_text(encoding="utf-8")
+    assert "Ganancia total" in content
+    assert "Caída máxima" in content
+    assert "Consistencia" in content

--- a/tests/test_hybrid_policy_block.py
+++ b/tests/test_hybrid_policy_block.py
@@ -1,0 +1,22 @@
+from src.policies.hybrid import HybridPolicy
+
+
+class Dummy:
+    def __init__(self, val: int):
+        self.val = val
+
+    def act(self, obs):
+        return self.val
+
+
+def test_record_trade_updates_weights():
+    pol = HybridPolicy({"a": Dummy(0), "b": Dummy(1)}, {"a": 0.5, "b": 0.5}, block_size=2)
+    m = {
+        "a": {"pnl": 1.0, "max_drawdown": 0.1},
+        "b": {"pnl": 0.0, "max_drawdown": 0.2},
+    }
+    pol.record_trade(m)
+    before = pol.weights.copy()
+    pol.record_trade(m)
+    assert pol.weights["a"] > pol.weights["b"]
+    assert pol.weights != before

--- a/tests/test_simulator_filters.py
+++ b/tests/test_simulator_filters.py
@@ -1,0 +1,54 @@
+import logging
+import pandas as pd
+
+from src.backtest.simulator import simulate
+
+
+class DummyPolicy:
+    def __init__(self):
+        self.calls = 0
+    def act(self, obs):
+        self.calls += 1
+        if self.calls == 1:
+            return 1  # open
+        if self.calls == 2:
+            return 2  # close
+        return 0
+
+
+class DummyMeta:
+    def get_symbol_filters(self, symbol: str):
+        return {"tickSize": 0.1, "stepSize": 0.5, "minNotional": 50.0}
+
+
+def test_simulator_logs_filters(monkeypatch, caplog):
+    df = pd.DataFrame({"close": [100.0, 101.0]})
+    monkeypatch.setattr(
+        "src.backtest.simulator.estimate_slippage", lambda *a, **k: 0.01
+    )
+    pol = DummyPolicy()
+    meta = DummyMeta()
+    with caplog.at_level(logging.INFO):
+        sim = simulate(df, pol, fees=0.0, symbol="BTC/USDT", meta=meta)
+    assert len(sim["trades"]) == 1
+    assert any(
+        "slippage=0.010000" in r.message
+        and "tick=0.100000" in r.message
+        and "step=0.500000" in r.message
+        and "minNotional=50.000000" in r.message
+        for r in caplog.records
+    )
+
+
+def test_simulator_blocks_min_notional(monkeypatch):
+    df = pd.DataFrame({"close": [1.0, 1.0]})
+    class MetaHigh:
+        def get_symbol_filters(self, symbol: str):
+            return {"tickSize": 0.1, "stepSize": 0.1, "minNotional": 10.0}
+    pol = DummyPolicy()
+    meta = MetaHigh()
+    monkeypatch.setattr(
+        "src.backtest.simulator.estimate_slippage", lambda *a, **k: 0.0
+    )
+    sim = simulate(df, pol, fees=0.0, symbol="BTC/USDT", meta=meta)
+    assert sim["trades"] == []

--- a/tests/test_volatility_windows.py
+++ b/tests/test_volatility_windows.py
@@ -1,0 +1,61 @@
+import time
+import pandas as pd
+
+from src.data.volatility_windows import find_high_activity_windows
+
+
+class DummyExchange:
+    id = "binance"
+
+    def __init__(self):
+        self.trades: list[dict] = []
+
+    def seed(self, start: int, counts):
+        for h, count in counts.items():
+            base = start + h * 3600000
+            for i in range(count):
+                self.trades.append({"timestamp": base + i})
+
+    def fetch_trades(self, symbol, since=None, limit=1000):
+        since = since or 0
+        res = [t for t in self.trades if t["timestamp"] >= since]
+        return res[:limit]
+
+
+def test_selects_top_volatility_windows(tmp_path, monkeypatch):
+    end = int(time.time() * 1000)
+    start = end - 3 * 3600000
+    rows = []
+    for i in range(60):
+        ts = start + i * 60000
+        rows.append([ts, 100, 100, 100, 100, 1])
+    for i in range(60, 120):
+        ts = start + i * 60000
+        price = 100 + (i - 60)
+        rows.append([ts, price, price, price, price, 10])
+    for i in range(120, 180):
+        ts = start + i * 60000
+        rows.append([ts, 100, 100, 100, 100, 5])
+    df = pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
+    path = tmp_path / "binance_BTC-USDT_1m.parquet"
+    df.to_parquet(path)
+
+    def fake_ensure(exchange, symbol, timeframe, hours, root=None):
+        return path
+
+    monkeypatch.setattr(
+        "src.data.volatility_windows.ensure_ohlcv", fake_ensure
+    )
+
+    ex = DummyExchange()
+    ex.seed(start, {0: 10, 1: 100, 2: 30})
+
+    windows, lookback = find_high_activity_windows(
+        ["BTC/USDT"], 1, target_hours=2, lookback_hours=3, exchange=ex
+    )
+
+    assert lookback == 3
+    hour_start = (start // 3600000) * 3600000
+    expected = (hour_start + 3600000, hour_start + 3 * 3600000)
+    assert windows == [expected]
+


### PR DESCRIPTION
## Summary
- rank high-activity windows by combining return volatility, traded volume, and trade counts while fetching only the needed OHLCV data
- update the UI to preview the most intense windows and total hours while downloading only required segments
- add a unit test covering the volatility window selector

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d2d1944c832899483066b012d462