### PR TITLE
Centralize path helpers and normalize symbols

### DIFF
--- a/src/data/ccxt_loader.py
+++ b/src/data/ccxt_loader.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import os
 import logging
 from typing import Any, Optional
+from pathlib import Path
 
 import pandas as pd
+
+from ..utils import paths
 
 __all__ = [
     "simulate_1s_from_1m",
@@ -129,13 +132,14 @@ def fetch_ohlcv(
 
 
 def save_history(
-    df: pd.DataFrame, root_dir: str, exchange: str, symbol: str, timeframe: str
+    df: pd.DataFrame, root_dir: os.PathLike[str] | str, exchange: str, symbol: str, timeframe: str
 ) -> str:
     """Persist OHLCV *df* as CSV and return the output path."""
 
-    os.makedirs(root_dir, exist_ok=True)
-    fname = f"{exchange}_{symbol.replace('/', '-')}_{timeframe}.csv"
-    path = os.path.join(root_dir, fname)
-    df.to_csv(path, index=False)
-    return path
+    root = Path(root_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    fname = f"{exchange}_{paths.symbol_to_dir(symbol)}_{timeframe}.csv"
+    out = root / fname
+    df.to_csv(paths.posix(out), index=False)
+    return paths.posix(out)
 

--- a/src/data/ensure.py
+++ b/src/data/ensure.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 import time
 from pathlib import Path
-from typing import Optional
 
 import pandas as pd
 
@@ -18,7 +17,6 @@ def ensure_ohlcv(
     timeframe: str,
     *,
     hours: int = 24,
-    root: Optional[Path | str] = None,
 ) -> Path:
     """Ensure a parquet file with OHLCV data exists and return its path.
 
@@ -27,7 +25,7 @@ def ensure_ohlcv(
     rate limits.  When downloading fails a ``RuntimeError`` is raised.
     """
 
-    path = raw_parquet_path(exchange, symbol, timeframe, root)
+    path = raw_parquet_path(exchange, symbol, timeframe)
     if path.exists():
         return path
 

--- a/src/utils/data_io.py
+++ b/src/utils/data_io.py
@@ -4,6 +4,8 @@ import os
 import numpy as np
 import pandas as pd
 
+from .paths import raw_parquet_path, posix
+
 REQUIRED_OHLCV_COLUMNS = [
     "ts",
     "open",
@@ -188,9 +190,8 @@ def validate_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def save_ohlcv(df: pd.DataFrame, root: str, exchange: str, symbol: str, timeframe: str) -> str:
+def save_ohlcv(df: pd.DataFrame, exchange: str, symbol: str, timeframe: str) -> str:
     df = validate_ohlcv(df)
-    sym_fs = symbol.replace("/", "_")
-    path = os.path.join(root, exchange, sym_fs, f"{timeframe}.parquet")
-    save_table(df, path)
-    return path
+    path = raw_parquet_path(exchange, symbol, timeframe)
+    save_table(df, posix(path))
+    return posix(path)

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,53 +1,37 @@
-from __future__ import annotations
-
-"""Helper utilities for resolving common project directories."""
-
+import os
 from pathlib import Path
-from typing import Any, Mapping
 
+RAW_DIR = Path(os.getenv("DRLTB_RAW_DIR", "data/raw"))
+REPORTS_DIR = Path(os.getenv("DRLTB_REPORTS_DIR", "reports"))
+CHECKPOINTS_DIR = Path(os.getenv("DRLTB_CHECKPOINTS_DIR", "checkpoints"))
 
-def _paths(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Return the ``paths`` section from the config or an empty mapping."""
-    return cfg.get("paths", {}) if isinstance(cfg, Mapping) else {}
+def symbol_to_dir(sym: str) -> str:
+    """Convert a market symbol to a filesystem-friendly name.
 
-
-def get_raw_dir(cfg: Mapping[str, Any]) -> Path:
-    """Return the directory containing raw market data."""
-    return Path(_paths(cfg).get("raw_dir", "data/raw"))
-
-
-def get_reports_dir(cfg: Mapping[str, Any]) -> Path:
-    """Return the directory where evaluation reports are stored."""
-    return Path(_paths(cfg).get("reports_dir", "reports"))
-
-
-def get_checkpoints_dir(cfg: Mapping[str, Any]) -> Path:
-    """Return the directory for model checkpoints."""
-    return Path(_paths(cfg).get("checkpoints_dir", "checkpoints"))
-
-
-def ensure_dirs_exist(cfg: Mapping[str, Any]) -> None:
-    """Create common project directories if they do not already exist."""
-    for directory in [get_raw_dir(cfg), get_reports_dir(cfg), get_checkpoints_dir(cfg)]:
-        directory.mkdir(parents=True, exist_ok=True)
-
-
-def symbol_to_dir(symbol: str) -> str:
-    """Return the on-disk representation for a trading pair.
-
-    ``"ETH/USDT"`` -> ``"ETH-USDT"``
+    Examples
+    --------
+    >>> symbol_to_dir("ETH/USDT")
+    'ETH-USDT'
     """
+    return sym.replace("/", "-")
 
-    return symbol.replace("/", "-")
+def dir_to_symbol(d: str) -> str:
+    """Convert on-disk directory name back to market symbol."""
+    return d.replace("-", "/")
 
+def raw_parquet_path(exchange: str, symbol: str, timeframe: str) -> Path:
+    """Path for raw OHLCV parquet file."""
+    return RAW_DIR / exchange / symbol_to_dir(symbol) / f"{timeframe}.parquet"
 
-def raw_parquet_path(
-    exchange: str,
-    symbol: str,
-    timeframe: str,
-    root: Path | str | None = None,
-) -> Path:
-    """Return the path to the raw OHLCV parquet file."""
+def reports_dir() -> Path:
+    return REPORTS_DIR
 
-    base = Path(root) if root else Path("data/raw")
-    return base / exchange / symbol_to_dir(symbol) / f"{timeframe}.parquet"
+def checkpoints_dir() -> Path:
+    return CHECKPOINTS_DIR
+
+def ensure_dirs_exist() -> None:
+    for p in [RAW_DIR, REPORTS_DIR, CHECKPOINTS_DIR]:
+        p.mkdir(parents=True, exist_ok=True)
+
+def posix(p: Path) -> str:
+    return p.as_posix()


### PR DESCRIPTION
## Summary
- Add `paths` utility with POSIX conversion, symbol-to-dir helpers, and common directories
- Refactor data loading, training, evaluation, and scripts to rely on `paths` and Path objects
- Allow directory overrides via environment variables and update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e722de50832887f98ce24909e1fc