### PR TITLE
feat: adapt timeframe during training and stream live logs

### DIFF
--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -2,5 +2,6 @@
 
 from .strategy_selector import choose_algo
 from .hparam_tuner import tune
+from .timeframe_adapter import propose_timeframe
 
-__all__ = ["choose_algo", "tune"]
+__all__ = ["choose_algo", "tune", "propose_timeframe"]

--- a/src/auto/timeframe_adapter.py
+++ b/src/auto/timeframe_adapter.py
@@ -1,0 +1,77 @@
+"""Simple timeframe adaptation heuristics."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+import json
+
+
+def propose_timeframe(
+    stats: Dict[str, Any],
+    vol_profile: Dict[str, float],
+    latency_budget: float,
+    llm: Any | None = None,
+) -> Dict[str, str]:
+    """Return a timeframe suggestion based on recent stats.
+
+    Parameters
+    ----------
+    stats:
+        Dictionary with keys ``recent_volatility``, ``gap_ratio``, ``device``,
+        ``batch_size``, ``base_tf`` and ``current_tf``.
+    vol_profile:
+        Thresholds with ``high`` and ``low`` volatility markers.
+    latency_budget:
+        Available compute budget on a 0-1 scale where higher allows finer
+        resampling.
+    llm:
+        Optional LLM client implementing ``ask``. When provided, the heuristic
+        proposal is sent for feedback and may be refined.
+    """
+
+    base_tf = stats.get("base_tf", "1m")
+    current_tf = stats.get("current_tf", base_tf)
+    vol = float(stats.get("recent_volatility", 0.0))
+    gap_ratio = float(stats.get("gap_ratio", 0.0))
+
+    # Heuristic proposal -------------------------------------------------
+    if gap_ratio > 0.3:
+        resample = current_tf
+        reason = "muchos huecos"
+    elif vol > vol_profile.get("high", 0.02):
+        resample = "5s" if latency_budget >= 1.0 else "15s"
+        reason = "alta volatilidad"
+    elif vol < vol_profile.get("low", 0.005):
+        resample = "30s"
+        reason = "baja volatilidad"
+    else:
+        resample = "15s"
+        reason = "volatilidad moderada"
+
+    proposal = {"base_tf": base_tf, "resample_to": resample, "reason": reason}
+
+    # LLM refinement -----------------------------------------------------
+    if llm is not None:
+        ctx = (
+            f"vol={vol:.4f}, gaps={gap_ratio:.2f}, actual={current_tf},"
+            f" device={stats.get('device')}, batch={stats.get('batch_size')}"
+        )
+        prompt = (
+            "Sugiere timeframe (5s,15s,30s,1m) para entrenamiento dado: "
+            f"{ctx}. Devuelve JSON con claves 'resample_to' y 'reason'."
+        )
+        try:  # pragma: no cover - network interaction
+            resp = llm.ask("Asistente timeframe", prompt)
+            data = json.loads(resp)
+            cand = data.get("resample_to")
+            if cand in {"5s", "15s", "30s", "1m"}:
+                proposal["resample_to"] = cand
+                proposal["reason"] = data.get("reason", "llm")
+        except Exception:
+            pass
+
+    return proposal
+
+
+__all__ = ["propose_timeframe"]
+

--- a/src/data/volatility_windows.py
+++ b/src/data/volatility_windows.py
@@ -70,6 +70,8 @@ def find_high_activity_windows(
         lookback_hours = target_hours * 6
     end = int(time.time() * 1000)
     since = end - lookback_hours * 3600000
+    start_hour = _hour_floor(since)
+    end_cap = start_hour + lookback_hours * 3600000
 
     frames: List[pd.DataFrame] = []
     trade_frames: List[pd.DataFrame] = []
@@ -79,11 +81,11 @@ def find_high_activity_windows(
                 ex.id if hasattr(ex, "id") else "binance", sym, tf_str, hours=lookback_hours
             )
             df = pd.read_parquet(path)
-            df = df[df["ts"] >= since]
+            df = df[(df["ts"] >= start_hour) & (df["ts"] < end_cap)]
             df["symbol"] = sym
             frames.append(df)
 
-            trade_counts = _fetch_trade_counts(ex, sym, since, end)
+            trade_counts = _fetch_trade_counts(ex, sym, start_hour, end_cap)
             if not trade_counts.empty:
                 trade_frames.append(trade_counts)
         except Exception as exc:  # pragma: no cover - network dependent

--- a/src/ui/log_stream.py
+++ b/src/ui/log_stream.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import logging
+import time
+from collections import deque
+from datetime import datetime, UTC
+from typing import Deque, Dict, Iterator, Optional, Set
+
+_LOG_BUFFER: Deque[Dict[str, object]] = deque(maxlen=1000)
+
+_EVENT_MAP = {
+    "trade_executed": (
+        lambda r: f"Ejecutada orden {getattr(r, 'side', '?')} {getattr(r, 'qty', '?')} en {getattr(r, 'symbol', '?')} a {getattr(r, 'price', '?')}",
+        "trades",
+    ),
+    "risk_blocked_min_notional": (
+        lambda r: "Orden cancelada: mínima notional no alcanzada",
+        "riesgo",
+    ),
+    "slippage_est": (
+        lambda r: f"Slippage estimado {getattr(r, 'pct', 0.0):.2%} por tamaño {getattr(r, 'usd', '?')}",
+        "datos",
+    ),
+    "checkpoint_saved": (
+        lambda r: f"Checkpoint guardado (pasos={getattr(r, 'steps', '?')})",
+        "checkpoints",
+    ),
+}
+
+class _StreamHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - passthrough
+        event = getattr(record, "event", None)
+        formatter = _EVENT_MAP.get(event)
+        if formatter:
+            msg = formatter[0](record)
+            kind = formatter[1]
+        else:
+            msg = record.getMessage()
+            kind = getattr(record, "kind", event) or "general"
+        _LOG_BUFFER.append(
+            {
+                "time": datetime.fromtimestamp(record.created, UTC),
+                "level": record.levelname.lower(),
+                "levelno": record.levelno,
+                "kind": kind,
+                "message": msg,
+            }
+        )
+
+_handler_installed = False
+
+def _ensure_handler() -> None:
+    global _handler_installed
+    if not _handler_installed:
+        logging.getLogger().addHandler(_StreamHandler())
+        _handler_installed = True
+
+_ensure_handler()
+
+def subscribe(level: str = "info", kinds: Optional[Set[str]] = None) -> Iterator[Dict[str, object]]:
+    """Yield log entries filtered by level and kinds."""
+    levelno = getattr(logging, level.upper(), logging.INFO)
+    kinds = kinds or set()
+    idx = 0
+    while True:
+        while idx < len(_LOG_BUFFER):
+            item = _LOG_BUFFER[idx]
+            idx += 1
+            if item["levelno"] >= levelno and (not kinds or item["kind"] in kinds):
+                yield item
+        time.sleep(0.1)


### PR DESCRIPTION
## Summary
- add timeframe_adapter utility with heuristic & LLM-assisted proposals
- adjust resampling utilities and volatility window selection
- dynamically reload environment with new timeframe during DQN training
- stream logging events through queue with human-friendly messages
- show live log feed in Streamlit UI with filtering and pause

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4f0c487f083288334dd7c6f6ac25d