### PR TITLE
feat: adapt timeframe during training and stream live logs

### DIFF
--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -2,5 +2,6 @@
 
 from .strategy_selector import choose_algo
 from .hparam_tuner import tune
+from .timeframe_adapter import propose_timeframe
 
-__all__ = ["choose_algo", "tune"]
+__all__ = ["choose_algo", "tune", "propose_timeframe"]

--- a/src/auto/timeframe_adapter.py
+++ b/src/auto/timeframe_adapter.py
@@ -1,0 +1,77 @@
+"""Simple timeframe adaptation heuristics."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+import json
+
+
+def propose_timeframe(
+    stats: Dict[str, Any],
+    vol_profile: Dict[str, float],
+    latency_budget: float,
+    llm: Any | None = None,
+) -> Dict[str, str]:
+    """Return a timeframe suggestion based on recent stats.
+
+    Parameters
+    ----------
+    stats:
+        Dictionary with keys ``recent_volatility``, ``gap_ratio``, ``device``,
+        ``batch_size``, ``base_tf`` and ``current_tf``.
+    vol_profile:
+        Thresholds with ``high`` and ``low`` volatility markers.
+    latency_budget:
+        Available compute budget on a 0-1 scale where higher allows finer
+        resampling.
+    llm:
+        Optional LLM client implementing ``ask``. When provided, the heuristic
+        proposal is sent for feedback and may be refined.
+    """
+
+    base_tf = stats.get("base_tf", "1m")
+    current_tf = stats.get("current_tf", base_tf)
+    vol = float(stats.get("recent_volatility", 0.0))
+    gap_ratio = float(stats.get("gap_ratio", 0.0))
+
+    # Heuristic proposal -------------------------------------------------
+    if gap_ratio > 0.3:
+        resample = current_tf
+        reason = "muchos huecos"
+    elif vol > vol_profile.get("high", 0.02):
+        resample = "5s" if latency_budget >= 1.0 else "15s"
+        reason = "alta volatilidad"
+    elif vol < vol_profile.get("low", 0.005):
+        resample = "30s"
+        reason = "baja volatilidad"
+    else:
+        resample = "15s"
+        reason = "volatilidad moderada"
+
+    proposal = {"base_tf": base_tf, "resample_to": resample, "reason": reason}
+
+    # LLM refinement -----------------------------------------------------
+    if llm is not None:
+        ctx = (
+            f"vol={vol:.4f}, gaps={gap_ratio:.2f}, actual={current_tf},"
+            f" device={stats.get('device')}, batch={stats.get('batch_size')}"
+        )
+        prompt = (
+            "Sugiere timeframe (5s,15s,30s,1m) para entrenamiento dado: "
+            f"{ctx}. Devuelve JSON con claves 'resample_to' y 'reason'."
+        )
+        try:  # pragma: no cover - network interaction
+            resp = llm.ask("Asistente timeframe", prompt)
+            data = json.loads(resp)
+            cand = data.get("resample_to")
+            if cand in {"5s", "15s", "30s", "1m"}:
+                proposal["resample_to"] = cand
+                proposal["reason"] = data.get("reason", "llm")
+        except Exception:
+            pass
+
+    return proposal
+
+
+__all__ = ["propose_timeframe"]
+

--- a/src/data/volatility_windows.py
+++ b/src/data/volatility_windows.py
@@ -70,6 +70,8 @@ def find_high_activity_windows(
         lookback_hours = target_hours * 6
     end = int(time.time() * 1000)
     since = end - lookback_hours * 3600000
+    start_hour = _hour_floor(since)
+    end_cap = start_hour + lookback_hours * 3600000
 
     frames: List[pd.DataFrame] = []
     trade_frames: List[pd.DataFrame] = []
@@ -79,11 +81,11 @@ def find_high_activity_windows(
                 ex.id if hasattr(ex, "id") else "binance", sym, tf_str, hours=lookback_hours
             )
             df = pd.read_parquet(path)
-            df = df[df["ts"] >= since]
+            df = df[(df["ts"] >= start_hour) & (df["ts"] < end_cap)]
             df["symbol"] = sym
             frames.append(df)
 
-            trade_counts = _fetch_trade_counts(ex, sym, since, end)
+            trade_counts = _fetch_trade_counts(ex, sym, start_hour, end_cap)
             if not trade_counts.empty:
                 trade_frames.append(trade_counts)
         except Exception as exc:  # pragma: no cover - network dependent

--- a/src/training/train_drl.py
+++ b/src/training/train_drl.py
@@ -33,8 +33,9 @@ import pandas as pd
 
 from ..env.trading_env import TradingEnv
 from ..auto.hparam_tuner import tune
+from ..auto.timeframe_adapter import propose_timeframe
 from ..utils.config import load_config
-from ..utils.data_io import load_table
+from ..utils.data_io import load_table, resample_to
 from ..utils.logging import ensure_logger, config_hash
 from ..utils import paths
 from ..utils.device import get_device, set_cpu_threads
@@ -303,11 +304,19 @@ def train_value_dqn(
     llm_client = None
     llm_file = None
     llm_every = int(llm_cfg.get("every_n") or 0)
+    llm_mode = llm_cfg.get("mode", "episodes")
+    last_llm_time = time.time()
     if llm_cfg.get("enabled") and llm_cfg.get("periodic") and llm_every > 0:
         llm_client = LLMClient(model=llm_cfg.get("model", "gpt-4o"))
         reports_dir = paths.reports_dir()
         reports_dir.mkdir(parents=True, exist_ok=True)
         llm_file = open(reports_dir / "llm_suggestions.jsonl", "a", encoding="utf-8")
+
+    auto_cfg = cfg.get("auto", {})
+    stage_eps = int(auto_cfg.get("timeframe_every_episodes", 0))
+    base_tf = cfg.get("timeframe", "1m")
+    base_df = env.df.copy()
+    current_tf = base_tf
 
     total_steps = 0
     episode = 0
@@ -324,7 +333,41 @@ def train_value_dqn(
     backoff = 60.0
     while total_steps < timesteps:
         try:
-            obs, _ = env.reset()
+            seed_override = None
+            if stage_eps and episode % stage_eps == 0:
+                returns = env.df["close"].pct_change().dropna()
+                recent_vol = float(returns.rolling(20).std().iloc[-1]) if not returns.empty else 0.0
+                gaps = np.diff(env.df["ts"].to_numpy())
+                step = pd.Series(gaps).mode().iloc[0] if len(gaps) else 0
+                gap_ratio = float((gaps > step * 1.5).mean()) if step else 0.0
+                stats = {
+                    "recent_volatility": recent_vol,
+                    "gap_ratio": gap_ratio,
+                    "device": dqn_cfg.get("device", "cpu"),
+                    "batch_size": dqn_cfg.get("batch_size", 64),
+                    "base_tf": base_tf,
+                    "current_tf": current_tf,
+                }
+                vol_prof = auto_cfg.get("vol_profile", {"high": 0.02, "low": 0.005})
+                lat_budget = 1.0 if dqn_cfg.get("device") == "cuda" else 0.5
+                proposal = propose_timeframe(stats, vol_prof, lat_budget, llm_client if llm_cfg.get("enabled") else None)
+                if proposal["resample_to"] != current_tf:
+                    current_tf = proposal["resample_to"]
+                    new_df = resample_to(base_df, current_tf)
+                    env = TradingEnv(new_df, cfg=env.cfg)
+                    seed_override = random.randint(0, 2**32 - 1)
+                    logger.log(
+                        "INFO",
+                        "timeframe_adapted",
+                        base=proposal["base_tf"],
+                        resample=current_tf,
+                        reason=proposal["reason"],
+                        seed=seed_override,
+                    )
+                    print(
+                        f"Timeframe adaptado: base={proposal['base_tf']} \u2192 resample={current_tf} (motivo: {proposal['reason']})"
+                    )
+            obs, _ = env.reset(seed=seed_override)
             done = False
             episode += 1
             ep_reward = 0.0
@@ -336,9 +379,27 @@ def train_value_dqn(
                 obs = next_obs
                 total_steps += 1
                 ep_reward += reward
+                now = time.time()
+                if (
+                    llm_client
+                    and llm_mode == "minutes"
+                    and llm_every > 0
+                    and now - last_llm_time >= llm_every * 60
+                ):
+                    mean_reward = (total_reward + ep_reward) / max(1, episode)
+                    _maybe_call_llm(
+                        cfg,
+                        "dqn",
+                        episode,
+                        mean_reward,
+                        env,
+                        llm_client,
+                        llm_file,
+                        logger,
+                    )
+                    last_llm_time = now
 
                 if continuous:
-                    now = time.time()
                     if checkpoint_interval_min and now - last_ckpt >= checkpoint_interval_min * 60:
                         _save_checkpoint(ckpt_path, agent, total_steps, episode, total_reward + ep_reward, start_time)
                         last_ckpt = now
@@ -358,7 +419,12 @@ def train_value_dqn(
                         return final_path
 
             total_reward += ep_reward
-            if llm_client and episode % llm_every == 0:
+            if (
+                llm_client
+                and llm_mode == "episodes"
+                and llm_every > 0
+                and episode % llm_every == 0
+            ):
                 mean_reward = total_reward / episode
                 _maybe_call_llm(
                     cfg,
@@ -426,11 +492,19 @@ def train_dqn(
     llm_client = None
     llm_file = None
     llm_every = int(llm_cfg.get("every_n") or 0)
+    llm_mode = llm_cfg.get("mode", "episodes")
+    last_llm_time = time.time()
     if llm_cfg.get("enabled") and llm_cfg.get("periodic") and llm_every > 0:
         llm_client = LLMClient(model=llm_cfg.get("model", "gpt-4o"))
         reports_dir = paths.reports_dir()
         reports_dir.mkdir(parents=True, exist_ok=True)
         llm_file = open(reports_dir / "llm_suggestions.jsonl", "a", encoding="utf-8")
+
+    auto_cfg = cfg.get("auto", {})
+    stage_eps = int(auto_cfg.get("timeframe_every_episodes", 0))
+    base_tf = cfg.get("timeframe", "1m")
+    base_df = env.df.copy()
+    current_tf = base_tf
 
     eps_start = dqn_cfg.get("epsilon_start", 1.0)
     eps_end = dqn_cfg.get("epsilon_end", 0.05)
@@ -440,7 +514,41 @@ def train_dqn(
     episode = 0
     total_reward = 0.0
     while total_steps < timesteps:
-        obs, _ = env.reset()
+        seed_override = None
+        if stage_eps and episode % stage_eps == 0:
+            returns = env.df["close"].pct_change().dropna()
+            recent_vol = float(returns.rolling(20).std().iloc[-1]) if not returns.empty else 0.0
+            gaps = np.diff(env.df["ts"].to_numpy())
+            step = pd.Series(gaps).mode().iloc[0] if len(gaps) else 0
+            gap_ratio = float((gaps > step * 1.5).mean()) if step else 0.0
+            stats = {
+                "recent_volatility": recent_vol,
+                "gap_ratio": gap_ratio,
+                "device": dqn_cfg.get("device", "cpu"),
+                "batch_size": dqn_cfg.get("batch_size", 64),
+                "base_tf": base_tf,
+                "current_tf": current_tf,
+            }
+            vol_prof = auto_cfg.get("vol_profile", {"high": 0.02, "low": 0.005})
+            lat_budget = 1.0 if dqn_cfg.get("device") == "cuda" else 0.5
+            proposal = propose_timeframe(stats, vol_prof, lat_budget, llm_client if llm_cfg.get("enabled") else None)
+            if proposal["resample_to"] != current_tf:
+                current_tf = proposal["resample_to"]
+                new_df = resample_to(base_df, current_tf)
+                env = TradingEnv(new_df, cfg=env.cfg)
+                seed_override = random.randint(0, 2**32 - 1)
+                logger.log(
+                    "INFO",
+                    "timeframe_adapted",
+                    base=proposal["base_tf"],
+                    resample=current_tf,
+                    reason=proposal["reason"],
+                    seed=seed_override,
+                )
+                print(
+                    f"Timeframe adaptado: base={proposal['base_tf']} \u2192 resample={current_tf} (motivo: {proposal['reason']})"
+                )
+        obs, _ = env.reset(seed=seed_override)
         done = False
         episode += 1
         ep_reward = 0.0
@@ -453,9 +561,33 @@ def train_dqn(
             obs = next_obs
             total_steps += 1
             ep_reward += reward
+            now = time.time()
+            if (
+                llm_client
+                and llm_mode == "minutes"
+                and llm_every > 0
+                and now - last_llm_time >= llm_every * 60
+            ):
+                mean_reward = (total_reward + ep_reward) / max(1, episode)
+                _maybe_call_llm(
+                    cfg,
+                    "dqn",
+                    episode,
+                    mean_reward,
+                    env,
+                    llm_client,
+                    llm_file,
+                    logger,
+                )
+                last_llm_time = now
 
         total_reward += ep_reward
-        if llm_client and episode % llm_every == 0:
+        if (
+            llm_client
+            and llm_mode == "episodes"
+            and llm_every > 0
+            and episode % llm_every == 0
+        ):
             mean_reward = total_reward / episode
             _maybe_call_llm(
                 cfg,

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,6 +1,7 @@
 import os, io, sys, json, subprocess, time
 from datetime import datetime, UTC
 import streamlit as st
+from src.ui.log_stream import subscribe as log_subscribe
 
 from src.utils.config import load_config
 from src.utils import paths
@@ -32,9 +33,10 @@ st.set_page_config(page_title="DRL Trading Config", layout="wide")
 
 st.title("⚙️ Configuración DRL Trading")
 
-for k, v in {"fee_maker": None, "fee_taker": None}.items():
-    if k not in st.session_state:
-        st.session_state[k] = v
+if "fee_taker" not in st.session_state:
+    st.session_state["fee_taker"] = None
+if "fee_maker" not in st.session_state:
+    st.session_state["fee_maker"] = None
 
 device = get_device()
 if device == "cuda":
@@ -87,22 +89,9 @@ with st.sidebar:
     cfg["symbols"] = selected_symbols
 
     fees_dict = cfg.get("fees", {})
-    current_fee_maker = st.session_state["fee_maker"] or float(fees_dict.get("maker", 0.001))
-    current_fee_taker = st.session_state["fee_taker"] or float(fees_dict.get("taker", 0.001))
-    st.number_input(
-        "Fee maker",
-        value=float(current_fee_maker),
-        step=0.0001,
-        format="%.6f",
-        key="fee_maker",
-    )
-    st.number_input(
-        "Fee taker",
-        value=float(current_fee_taker),
-        step=0.0001,
-        format="%.6f",
-        key="fee_taker",
-    )
+    default_fee_taker = float(fees_dict.get("taker", 0.001))
+    api_fee_taker = None
+    api_fee_maker = None
     btn_col, origin_col = st.columns([1, 1])
     with btn_col:
         if st.button("Actualizar comisiones"):
@@ -116,22 +105,39 @@ with st.sidebar:
                     selected_symbols[0].replace("/", "") if selected_symbols else next(iter(fee_map))
                 )
                 entry = fee_map.get(symbol_key) or next(iter(fee_map.values()))
-                st.session_state["fee_maker"] = entry.get("maker", current_fee_maker)
-                st.session_state["fee_taker"] = entry.get("taker", current_fee_taker)
+                api_fee_taker = entry.get("taker")
+                api_fee_maker = entry.get("maker")
                 st.session_state["fee_origin"] = meta.last_fee_origin
-                st.success(
-                    f"Maker {entry.get('maker',0)} | Taker {entry.get('taker',0)}"
-                )
-                st.experimental_rerun()
+                st.success(f"Maker {api_fee_maker} | Taker {api_fee_taker}")
             except Exception as e:
                 st.error(f"No se pudo obtener: {e}")
     with origin_col:
         origin = st.session_state.get("fee_origin")
         if origin:
             st.caption(origin)
+
+    fee_taker = api_fee_taker or st.session_state["fee_taker"] or default_fee_taker
+    fee_maker = api_fee_maker or st.session_state["fee_maker"] or fee_taker
+    st.session_state["fee_taker"] = fee_taker
+    st.session_state["fee_maker"] = fee_maker
+
+    st.number_input(
+        "Fee taker",
+        value=float(fee_taker),
+        step=0.0001,
+        format="%.6f",
+        key="fee_taker",
+    )
+    st.number_input(
+        "Fee maker",
+        value=float(fee_maker),
+        step=0.0001,
+        format="%.6f",
+        key="fee_maker",
+    )
     cfg["fees"] = {
-        "maker": st.session_state["fee_maker"] or current_fee_maker,
-        "taker": st.session_state["fee_taker"] or current_fee_taker,
+        "maker": st.session_state["fee_maker"] or fee_maker,
+        "taker": st.session_state["fee_taker"] or fee_taker,
     }
     slippage_mult = st.number_input(
         "Multiplicador slippage",
@@ -260,17 +266,34 @@ with st.sidebar:
     )
     llm_reason = st.checkbox("Usar LLM para decisiones razonadas")
     llm_periodic = st.checkbox("Llamadas periódicas durante entrenamiento")
-    llm_every = (
-        st.number_input("cada N episodios", value=10, min_value=1, step=1)
-        if llm_periodic
-        else None
-    )
+    llm_mode = "Por episodios"
+    llm_every = 0
+    if llm_periodic:
+        llm_mode = st.radio("Modo", ["Por episodios", "Por minutos"], index=0)
+        if llm_mode == "Por episodios":
+            llm_every = st.number_input(
+                "Frecuencia de consultas al asistente (en episodios)",
+                value=0,
+                min_value=0,
+                step=1,
+                help="Ej.: 50 = pedirá consejo al asistente cada 50 episodios. 0 = desactivado.",
+            )
+        else:
+            llm_every = st.number_input(
+                "Frecuencia de consultas al asistente (en minutos)",
+                value=0,
+                min_value=0,
+                step=1,
+                help="Ej.: 5 = pedirá consejo al asistente cada 5 minutos. 0 = desactivado.",
+            )
+    periodic_enabled = bool(llm_periodic and llm_every > 0)
     cfg["llm"] = {
         "model": llm_model,
-        "enabled": bool(llm_reason or llm_periodic),
+        "enabled": bool(llm_reason or periodic_enabled),
         "use_reasoned": bool(llm_reason),
-        "periodic": bool(llm_periodic),
-        "every_n": int(llm_every) if llm_every else None,
+        "periodic": periodic_enabled,
+        "mode": "minutes" if llm_mode == "Por minutos" else "episodes",
+        "every_n": int(llm_every),
     }
 
     if st.button("💾 Guardar config YAML"):
@@ -280,7 +303,7 @@ with st.sidebar:
             "binance_use_testnet": use_testnet,
             "symbols": selected_symbols,
             "timeframe": cfg.get("timeframe", "1m"),
-            "fees": {"taker": fees_taker, "maker": cfg.get("fees", {}).get("maker", fees_taker)},
+            "fees": {"taker": fee_taker, "maker": fee_maker},
             "slippage_multiplier": slippage_mult,
             "min_notional_usd": min_notional,
             "filters": {"tickSize": tick_size, "stepSize": step_size},
@@ -523,8 +546,10 @@ if st.button("📈 Evaluar"):
         if logs:
             st.expander("Logs").code(logs, language="bash")
 
-          reports_root = paths.reports_dir()
-        run_dirs = sorted(reports_root.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True)
+        reports_root = paths.reports_dir()
+        run_dirs = sorted(
+            reports_root.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True
+        )
         if run_dirs:
             latest = run_dirs[0]
             try:
@@ -541,5 +566,38 @@ if st.button("📈 Evaluar"):
             st.error(res.stderr)
     except Exception as e:
         st.error(f"Fallo al evaluar: {e}")
+st.subheader("Actividad en vivo")
+kind_options = ["trades", "riesgo", "datos", "checkpoints", "llm"]
+selected_kinds = st.multiselect("Tipos", kind_options, default=kind_options, key="log_kind_sel")
 
-st.caption("Consejo: usa un terminal aparte si prefieres ver logs en tiempo real mientras el entrenamiento corre.")
+if "log_paused" not in st.session_state:
+    st.session_state["log_paused"] = False
+
+if st.button("Pausar" if not st.session_state["log_paused"] else "Reanudar", key="pause_feed"):
+    st.session_state["log_paused"] = not st.session_state["log_paused"]
+
+placeholder = st.empty()
+if "log_lines" not in st.session_state:
+    st.session_state["log_lines"] = []
+
+if "log_iter" not in st.session_state or st.session_state.get("log_iter_kinds") != set(selected_kinds):
+    st.session_state["log_iter_kinds"] = set(selected_kinds)
+    st.session_state["log_iter"] = log_subscribe(kinds=set(selected_kinds))
+
+if not st.session_state["log_paused"]:
+    start = time.time()
+    gen = st.session_state["log_iter"]
+    while time.time() - start < 0.5:
+        try:
+            item = next(gen)
+            st.session_state["log_lines"].append(item["message"])
+        except StopIteration:
+            break
+        except Exception:
+            break
+    st.session_state["log_lines"] = st.session_state["log_lines"][-200:]
+placeholder.text("\n".join(st.session_state.get("log_lines", [])))
+
+if not st.session_state["log_paused"]:
+    time.sleep(0.5)
+    st.experimental_rerun()

--- a/src/ui/log_stream.py
+++ b/src/ui/log_stream.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import logging
+import time
+from collections import deque
+from datetime import datetime, UTC
+from typing import Deque, Dict, Iterator, Optional, Set
+
+_LOG_BUFFER: Deque[Dict[str, object]] = deque(maxlen=1000)
+
+_EVENT_MAP = {
+    "trade_executed": (
+        lambda r: f"Ejecutada orden {getattr(r, 'side', '?')} {getattr(r, 'qty', '?')} en {getattr(r, 'symbol', '?')} a {getattr(r, 'price', '?')}",
+        "trades",
+    ),
+    "risk_blocked_min_notional": (
+        lambda r: "Orden cancelada: mínima notional no alcanzada",
+        "riesgo",
+    ),
+    "slippage_est": (
+        lambda r: f"Slippage estimado {getattr(r, 'pct', 0.0):.2%} por tamaño {getattr(r, 'usd', '?')}",
+        "datos",
+    ),
+    "checkpoint_saved": (
+        lambda r: f"Checkpoint guardado (pasos={getattr(r, 'steps', '?')})",
+        "checkpoints",
+    ),
+}
+
+class _StreamHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - passthrough
+        event = getattr(record, "event", None)
+        formatter = _EVENT_MAP.get(event)
+        if formatter:
+            msg = formatter[0](record)
+            kind = formatter[1]
+        else:
+            msg = record.getMessage()
+            kind = getattr(record, "kind", event) or "general"
+        _LOG_BUFFER.append(
+            {
+                "time": datetime.fromtimestamp(record.created, UTC),
+                "level": record.levelname.lower(),
+                "levelno": record.levelno,
+                "kind": kind,
+                "message": msg,
+            }
+        )
+
+_handler_installed = False
+
+def _ensure_handler() -> None:
+    global _handler_installed
+    if not _handler_installed:
+        logging.getLogger().addHandler(_StreamHandler())
+        _handler_installed = True
+
+_ensure_handler()
+
+def subscribe(level: str = "info", kinds: Optional[Set[str]] = None) -> Iterator[Dict[str, object]]:
+    """Yield log entries filtered by level and kinds."""
+    levelno = getattr(logging, level.upper(), logging.INFO)
+    kinds = kinds or set()
+    idx = 0
+    while True:
+        while idx < len(_LOG_BUFFER):
+            item = _LOG_BUFFER[idx]
+            idx += 1
+            if item["levelno"] >= levelno and (not kinds or item["kind"] in kinds):
+                yield item
+        time.sleep(0.1)


### PR DESCRIPTION
## Summary
- add timeframe_adapter utility with heuristic & LLM-assisted proposals
- adjust resampling utilities and volatility window selection
- dynamically reload environment with new timeframe during DQN training
- stream logging events through queue with human-friendly messages
- show live log feed in Streamlit UI with filtering and pause
- initialize and persist fee settings to avoid UI errors
- clarify LLM assistant query cadence with episodic or minute-based scheduling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4f0c487f083288334dd7c6f6ac25d