### PR TITLE
feat: automatic reward weight tuning

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -44,6 +44,20 @@ reward_weights:
   dd: 0.2
   vol: 0.1
 
+reward_tuner:
+  enabled: true
+  freq_episodes: 50
+  delta: 0.05
+  bounds:
+    w_pnl: [0.5, 3.0]
+    w_drawdown: [0.0, 2.0]
+    w_volatility: [0.0, 2.0]
+    w_turnover: [0.0, 2.0]
+  score_weights:
+    lambda_dd: 1.0
+    kappa_consistency: 0.5
+    mu_activity: 0.1
+
 # Deterministic policy params
 deterministic_policy:
   base_threshold: 0.001   # required 5-tick log-return to enter

--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -3,5 +3,6 @@
 from .strategy_selector import choose_algo
 from .hparam_tuner import tune
 from .timeframe_adapter import propose_timeframe
+from .reward_tuner import RewardTuner, human_names as reward_human_names
 
-__all__ = ["choose_algo", "tune", "propose_timeframe"]
+__all__ = ["choose_algo", "tune", "propose_timeframe", "RewardTuner", "reward_human_names"]

--- a/src/auto/reward_tuner.py
+++ b/src/auto/reward_tuner.py
@@ -1,0 +1,173 @@
+"""Adaptive reward weight tuner based on local sensitivity and bandits."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import random
+from pathlib import Path
+from typing import Dict, Tuple, Any
+
+
+@dataclass
+class _BanditArm:
+    success: int = 1
+    trials: int = 1
+
+    def sample(self) -> float:
+        """Sample from a Beta distribution for Thompson sampling."""
+        return random.betavariate(self.success, self.trials - self.success)
+
+    def update(self, success: bool) -> None:
+        self.trials += 1
+        if success:
+            self.success += 1
+
+
+class RewardTuner:
+    """Propose small adjustments to reward weights using local sensitivity.
+
+    The tuner keeps track of past modifications and evaluates them with a
+    multi-armed bandit (one arm per weight-direction).  Proposals are stored in
+    ``memory_file`` as JSON lines allowing persistence across runs.
+    """
+
+    def __init__(
+        self,
+        init_weights: Dict[str, float],
+        bounds: Dict[str, Tuple[float, float]],
+        memory_file: Path,
+        delta: float = 0.05,
+        score_weights: Dict[str, float] | None = None,
+    ) -> None:
+        self.weights = dict(init_weights)
+        self.bounds = bounds
+        self.memory_file = Path(memory_file)
+        self.delta = float(delta)
+        sw = score_weights or {}
+        self.lambda_dd = float(sw.get("lambda_dd", 1.0))
+        self.kappa_cons = float(sw.get("kappa_consistency", 0.5))
+        self.mu_act = float(sw.get("mu_activity", 0.1))
+        self.bandit: Dict[str, Dict[str, _BanditArm]] = {
+            k: {"up": _BanditArm(), "down": _BanditArm()} for k in self.weights
+        }
+        self.last_action: Dict[str, Any] | None = None
+        self.memory_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def score(self, metrics: Dict[str, float]) -> float:
+        """Composite performance score.
+
+        ``metrics`` should contain keys ``pnl``, ``drawdown``, ``consistency``
+        and ``activity``.  Missing keys default to ``0.0``.
+        """
+
+        pnl = float(metrics.get("pnl", 0.0))
+        dd = float(metrics.get("drawdown", 0.0))
+        cons = float(metrics.get("consistency", 0.0))
+        act = float(metrics.get("activity", 0.0))
+        return pnl - self.lambda_dd * dd + self.kappa_cons * cons - self.mu_act * act
+
+    # ------------------------------------------------------------------
+    def propose(self, recent_metrics: Dict[str, float]) -> Dict[str, float]:
+        """Return new weights given ``recent_metrics``.
+
+        Local sensitivity is approximated from the sign and magnitude of the
+        metrics.  A Thompson-sampling bandit decides whether to increase or
+        decrease the chosen weight.
+        """
+
+        gradients = {
+            "w_pnl": recent_metrics.get("pnl", 0.0),
+            "w_drawdown": -recent_metrics.get("drawdown", 0.0),
+            "w_volatility": -recent_metrics.get("volatility", 0.0),
+            "w_turnover": -recent_metrics.get("turnover", 0.0),
+        }
+        mags = [abs(v) for v in gradients.values()]
+        if sum(mags) == 0:
+            key = random.choice(list(self.weights))
+        else:
+            r = random.random() * sum(mags)
+            cum = 0.0
+            key = list(self.weights)[0]
+            for k, m in gradients.items():
+                cum += abs(m)
+                if r <= cum:
+                    key = k
+                    break
+
+        arms = self.bandit[key]
+        dir_up = arms["up"].sample()
+        dir_down = arms["down"].sample()
+        direction = "up" if dir_up >= dir_down else "down"
+
+        factor = 1.0 + self.delta if direction == "up" else 1.0 - self.delta
+        prev_weights = dict(self.weights)
+        new_val = self.weights[key] * factor
+        low, high = self.bounds.get(key, (float("-inf"), float("inf")))
+        new_val = max(low, min(high, new_val))
+        self.weights[key] = new_val
+
+        self.last_action = {
+            "key": key,
+            "direction": direction,
+            "prev_weights": prev_weights,
+            "prev_metrics": recent_metrics,
+            "score_before": self.score(
+                {
+                    "pnl": recent_metrics.get("pnl", 0.0),
+                    "drawdown": recent_metrics.get("drawdown", 0.0),
+                    "consistency": recent_metrics.get("consistency", 0.0),
+                    "activity": recent_metrics.get("activity", 0.0),
+                }
+            ),
+        }
+        reason = f"grad={gradients[key]:.4f}"
+        self.last_action["reason"] = reason
+        return dict(self.weights)
+
+    # ------------------------------------------------------------------
+    def confirm(self, new_metrics: Dict[str, float]) -> None:
+        """Persist result of last proposal and update bandit statistics."""
+
+        if not self.last_action:
+            return
+        key = self.last_action["key"]
+        direction = self.last_action["direction"]
+        prev_w = self.last_action["prev_weights"]
+        score_before = self.last_action.get("score_before", 0.0)
+        score_after = self.score(new_metrics)
+        success = score_after >= score_before
+
+        self.bandit[key][direction].update(success)
+        record = {
+            "before": prev_w,
+            "after": dict(self.weights),
+            "metrics_before": self.last_action.get("prev_metrics"),
+            "metrics_after": new_metrics,
+            "score_before": score_before,
+            "score_after": score_after,
+            "success": success,
+            "direction": direction,
+            "weight": key,
+        }
+        with self.memory_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+        if not success:
+            self.weights = prev_w
+
+        self.last_action = None
+
+
+def human_names() -> Dict[str, str]:
+    """Return human friendly names for weight keys."""
+
+    return {
+        "w_pnl": "PnL",
+        "w_drawdown": "Drawdown",
+        "w_volatility": "Volatilidad",
+        "w_turnover": "Rotación",
+    }
+
+
+__all__ = ["RewardTuner", "human_names"]

--- a/src/training/train_drl.py
+++ b/src/training/train_drl.py
@@ -34,6 +34,7 @@ import pandas as pd
 from ..env.trading_env import TradingEnv
 from ..auto.hparam_tuner import tune
 from ..auto.timeframe_adapter import propose_timeframe
+from ..auto.reward_tuner import RewardTuner
 from ..utils.config import load_config
 from ..utils.data_io import load_table, resample_to
 from ..utils.logging import ensure_logger, config_hash
@@ -322,12 +323,32 @@ def train_value_dqn(
     base_tf = cfg.get("timeframe", "1m")
     base_df = env.df.copy()
     current_tf = base_tf
+
+    rt_cfg = cfg.get("reward_tuner", {})
+    tuner = None
+    if rt_cfg.get("enabled"):
+        bounds = {k: tuple(v) for k, v in rt_cfg.get("bounds", {}).items()}
+        reports_dir = paths.reports_dir()
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        tuner = RewardTuner(
+            {
+                "w_pnl": env.w_pnl,
+                "w_drawdown": env.w_dd,
+                "w_volatility": env.w_vol,
+                "w_turnover": env.w_turn,
+            },
+            bounds,
+            reports_dir / "reward_tuning_history.jsonl",
+            delta=float(rt_cfg.get("delta", 0.05)),
+            score_weights=rt_cfg.get("score_weights", {}),
+        )
+        tune_freq = int(rt_cfg.get("freq_episodes", 50))
+        block_metrics = {"pnl": 0.0, "drawdown": 0.0, "volatility": 0.0, "turnover": 0.0}
     exchange_name = cfg.get("exchange", "binance")
     symbol = (cfg.get("symbols") or ["BTC/USDT"])[0]
     data_path = paths.raw_parquet_path(exchange_name, symbol, base_tf)
     if continuous:
         start_refresh_worker(cfg.get("symbols", []), base_tf)
-
     total_steps = 0
     episode = 0
     total_reward = 0.0
@@ -384,12 +405,18 @@ def train_value_dqn(
                 ep_reward = 0.0
                 while not done and total_steps < timesteps:
                     action = agent.act(obs)
-                    next_obs, reward, done, trunc, _info = env.step(action)
+                    next_obs, reward, done, trunc, info = env.step(action)
                     agent.remember(obs, action, reward, next_obs, done or trunc)
                     agent.train_step()
                     obs = next_obs
                     total_steps += 1
                     ep_reward += reward
+                    if tuner:
+                        terms = info.get("reward_terms", {})
+                        block_metrics["pnl"] += float(terms.get("pnl", 0.0))
+                        block_metrics["drawdown"] += float(terms.get("drawdown", 0.0))
+                        block_metrics["volatility"] += float(terms.get("volatility", 0.0))
+                        block_metrics["turnover"] += float(terms.get("turnover", 0.0))
                     now = time.time()
                     if (
                         llm_client
@@ -444,6 +471,37 @@ def train_value_dqn(
                             return final_path
     
                 total_reward += ep_reward
+                if tuner and episode % tune_freq == 0:
+                    metrics = {
+                        "pnl": block_metrics["pnl"],
+                        "drawdown": block_metrics["drawdown"],
+                        "volatility": block_metrics["volatility"],
+                        "turnover": block_metrics["turnover"],
+                        "consistency": -block_metrics["volatility"],
+                        "activity": block_metrics["turnover"],
+                    }
+                    if tuner.last_action is not None:
+                        tuner.confirm(metrics)
+                    new_w = tuner.propose(metrics)
+                    env.w_pnl = new_w["w_pnl"]
+                    env.w_dd = new_w["w_drawdown"]
+                    env.w_vol = new_w["w_volatility"]
+                    env.w_turn = new_w["w_turnover"]
+                    upd = tuner.last_action
+                    if upd:
+                        arrow = "↑" if upd["direction"] == "up" else "↓"
+                        logger.log(
+                            "INFO",
+                            "reward_weight_adjusted",
+                            weight=upd["key"],
+                            direction=upd["direction"],
+                            value=new_w[upd["key"]],
+                            reason=upd.get("reason"),
+                        )
+                        print(
+                            f"RewardTuner {upd['key']} {arrow} -> {new_w[upd['key']]:.3f} ({upd.get('reason')})"
+                        )
+                    block_metrics = {k: 0.0 for k in block_metrics}
                 if (
                     llm_client
                     and llm_mode == "episodes"
@@ -542,6 +600,27 @@ def train_dqn(
     base_df = env.df.copy()
     current_tf = base_tf
 
+    rt_cfg = cfg.get("reward_tuner", {})
+    tuner = None
+    if rt_cfg.get("enabled"):
+        bounds = {k: tuple(v) for k, v in rt_cfg.get("bounds", {}).items()}
+        reports_dir = paths.reports_dir()
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        tuner = RewardTuner(
+            {
+                "w_pnl": env.w_pnl,
+                "w_drawdown": env.w_dd,
+                "w_volatility": env.w_vol,
+                "w_turnover": env.w_turn,
+            },
+            bounds,
+            reports_dir / "reward_tuning_history.jsonl",
+            delta=float(rt_cfg.get("delta", 0.05)),
+            score_weights=rt_cfg.get("score_weights", {}),
+        )
+        tune_freq = int(rt_cfg.get("freq_episodes", 50))
+        block_metrics = {"pnl": 0.0, "drawdown": 0.0, "volatility": 0.0, "turnover": 0.0}
+
     eps_start = dqn_cfg.get("epsilon_start", 1.0)
     eps_end = dqn_cfg.get("epsilon_end", 0.05)
     eps_decay_steps = dqn_cfg.get("epsilon_decay_steps", timesteps // 2 or 1)
@@ -591,12 +670,18 @@ def train_dqn(
         while not done and total_steps < timesteps:
             eps = max(eps_end, eps_start - (eps_start - eps_end) * (total_steps / eps_decay_steps))
             action = agent.act(obs, eps)
-            next_obs, reward, done, trunc, _info = env.step(action)
+            next_obs, reward, done, trunc, info = env.step(action)
             agent.remember(obs, action, reward, next_obs, done or trunc)
             agent.update()
             obs = next_obs
             total_steps += 1
             ep_reward += reward
+            if tuner:
+                terms = info.get("reward_terms", {})
+                block_metrics["pnl"] += float(terms.get("pnl", 0.0))
+                block_metrics["drawdown"] += float(terms.get("drawdown", 0.0))
+                block_metrics["volatility"] += float(terms.get("volatility", 0.0))
+                block_metrics["turnover"] += float(terms.get("turnover", 0.0))
             now = time.time()
             if (
                 llm_client
@@ -618,6 +703,37 @@ def train_dqn(
                 last_llm_time = now
 
         total_reward += ep_reward
+        if tuner and episode % tune_freq == 0:
+            metrics = {
+                "pnl": block_metrics["pnl"],
+                "drawdown": block_metrics["drawdown"],
+                "volatility": block_metrics["volatility"],
+                "turnover": block_metrics["turnover"],
+                "consistency": -block_metrics["volatility"],
+                "activity": block_metrics["turnover"],
+            }
+            if tuner.last_action is not None:
+                tuner.confirm(metrics)
+            new_w = tuner.propose(metrics)
+            env.w_pnl = new_w["w_pnl"]
+            env.w_dd = new_w["w_drawdown"]
+            env.w_vol = new_w["w_volatility"]
+            env.w_turn = new_w["w_turnover"]
+            upd = tuner.last_action
+            if upd:
+                arrow = "↑" if upd["direction"] == "up" else "↓"
+                logger.log(
+                    "INFO",
+                    "reward_weight_adjusted",
+                    weight=upd["key"],
+                    direction=upd["direction"],
+                    value=new_w[upd["key"]],
+                    reason=upd.get("reason"),
+                )
+                print(
+                    f"RewardTuner {upd['key']} {arrow} -> {new_w[upd['key']]:.3f} ({upd.get('reason')})"
+                )
+            block_metrics = {k: 0.0 for k in block_metrics}
         if (
             llm_client
             and llm_mode == "episodes"


### PR DESCRIPTION
## Summary
- add `RewardTuner` module for bandit-based reward weight adjustments with persistence
- integrate tuner into training loops and expose configuration
- enable reward tuning defaults in `configs/default.yaml`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5048cd2a483289bee851174f14da5