### PR TITLE
Add hybrid runtime support for training and backtest

### DIFF
--- a/src/training/train_drl.py
+++ b/src/training/train_drl.py
@@ -905,6 +905,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Train tiny DRL agents")
     parser.add_argument("--config", default="configs/default.yaml")
     parser.add_argument("--algo", default="dqn", help="dqn|tiny|ppo|hybrid")
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help="Entrena simultáneamente módulos DQN (señal) y PPO (control)",
+    )
     parser.add_argument("--algo-reason", default="", help="Descripción breve de la elección automática")
     parser.add_argument("--timesteps", type=int, default=10_000)
     parser.add_argument("--data", type=str, default=None, help="Optional path to CSV/Parquet data")
@@ -976,7 +981,7 @@ def main() -> None:
     if args.algo_reason:
         logger.log("INFO", "auto_algo", algo=args.algo, reason=args.algo_reason)
 
-    algo_key = args.algo.lower()
+    algo_key = "hybrid" if args.hybrid else args.algo.lower()
     if args.continuous and algo_key != "dqn":
         raise ValueError("--continuous is only supported for dqn")
     data_stats = {
@@ -1042,11 +1047,26 @@ def main() -> None:
             max_hours=args.max_hours,
             logger=logger,
         )
-        out = json.dumps({"ppo": ppo_path, "dqn": dqn_path})
+        combo = {
+            "dqn_signal": {
+                "checkpoint": dqn_path,
+                "seed": cfg.get("seed"),
+                "version": cfg.get("dqn", {}).get("version", 1),
+            },
+            "ppo_control": {
+                "checkpoint": ppo_path,
+                "seed": cfg.get("seed"),
+                "version": cfg.get("ppo", {}).get("version", 1),
+            },
+        }
+        combo_path = ckpt_dir / "combo.json"
+        with open(combo_path, "w", encoding="utf-8") as fh:
+            json.dump(combo, fh, indent=2)
+        out = paths.posix(combo_path)
     else:  # pragma: no cover
         raise ValueError(f"Unknown algorithm: {args.algo}")
 
-    logger.log("INFO", "training_done", algo=args.algo, artifact=out)
+    logger.log("INFO", "training_done", algo=algo_key, artifact=out)
     print(f"Saved model/checkpoint to: {out}")
 
 

--- a/tests/test_algo_controller.py
+++ b/tests/test_algo_controller.py
@@ -1,0 +1,13 @@
+from src.auto import AlgoController
+
+
+def test_high_vol_and_td_error_mapping():
+    ctrl = AlgoController()
+    mapping = ctrl.decide(
+        {"intraminute": True},
+        {"volatility": 0.05},
+        {"td_error": 2.0},
+    )
+    assert mapping["entries_exits"] == "dqn"
+    assert mapping["risk_limits"] == "ppo"
+    assert mapping["position_sizing"] == "ppo"

--- a/tests/test_hybrid_runtime.py
+++ b/tests/test_hybrid_runtime.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.policy import HybridRuntime
+from src.auto import AlgoController
+
+
+class DummyDQN:
+    def act(self, obs):
+        return {"side": "buy", "qty": 0.05, "price": 100.0}
+
+
+class DummyPPO:
+    def __init__(self, min_notional, slippage):
+        self.min_notional = min_notional
+        self.slippage = slippage
+        self.act_called = False
+
+    def act(self, obs):
+        self.act_called = True
+        return {"side": "sell"}
+
+    def filter(self, signal, obs):
+        qty = max(signal["qty"], self.min_notional / signal["price"])
+        price = signal["price"] * (1 + self.slippage)
+        return {**signal, "qty": qty, "price": price}
+
+
+def test_hybrid_runtime_applies_control():
+    controller = AlgoController()
+    ppo = DummyPPO(min_notional=10.0, slippage=0.01)
+    runtime = HybridRuntime(DummyDQN(), ppo, controller)
+    action = runtime.act(
+        {"price": 100.0},
+        stage_info={"intraminute": True},
+        data_profile={"volatility": 0.05},
+        stability={"td_error": 2.0},
+    )
+    assert action["qty"] == pytest.approx(0.1)
+    assert action["price"] == pytest.approx(101.0)
+    assert action["side"] == "buy"
+    assert not ppo.act_called

--- a/tests/test_reward_tuner.py
+++ b/tests/test_reward_tuner.py
@@ -1,0 +1,36 @@
+import json
+import random
+from pathlib import Path
+
+from src.auto import RewardTuner
+
+
+def _ensure_bandit_valid(rt: RewardTuner) -> None:
+    """Adjust bandit arms to avoid zero-variance beta draws."""
+    for arms in rt.bandit.values():
+        for arm in arms.values():
+            arm.trials = arm.success + 1
+
+
+def test_propose_and_confirm(tmp_path):
+    random.seed(0)
+    mem = tmp_path / "mem.jsonl"
+    tuner = RewardTuner({"w_pnl": 1.0}, {"w_pnl": (0.5, 2.0)}, mem)
+    _ensure_bandit_valid(tuner)
+
+    before = dict(tuner.weights)
+    proposal = tuner.propose({"pnl": 1.0})
+    assert proposal["w_pnl"] != before["w_pnl"]
+
+    tuner.confirm({"pnl": 2.0})
+    assert tuner.weights["w_pnl"] == proposal["w_pnl"]
+    records = [json.loads(line) for line in mem.read_text().splitlines()]
+    assert records[-1]["success"] is True
+
+    _ensure_bandit_valid(tuner)
+    prev = dict(tuner.weights)
+    tuner.propose({"pnl": 1.0})
+    tuner.confirm({"pnl": -1.0})
+    assert tuner.weights["w_pnl"] == prev["w_pnl"]
+    records = [json.loads(line) for line in mem.read_text().splitlines()]
+    assert records[-1]["success"] is False


### PR DESCRIPTION
## Summary
- Add `--hybrid` flag to training CLI to train DQN signal and PPO control modules and save a combined `combo.json`
- Support hybrid runtime in backtesting with new CLI flag and HybridRuntime wrapper
- Report separate signal and control metrics including human-readable summary
- Cover reward tuner, algorithm controller, and hybrid runtime behavior with dedicated tests

## Testing
- `pytest tests/test_reward_tuner.py tests/test_algo_controller.py tests/test_hybrid_runtime.py -vv`
- `pytest tests/test_hybrid_policy_block.py tests/test_auto_utils.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a55687a1448328897a9b746aba4379