### PR TITLE
Add hybrid logging categories and filters

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -58,6 +58,16 @@ reward_tuner:
     kappa_consistency: 0.5
     mu_activity: 0.1
 
+hybrid:
+  enabled: true
+  train_both: true
+
+algo_controller:
+  llm_enabled: false
+
+stage_scheduler:
+  enabled: true
+
 auto:
   stage_thresholds:
     delta_score: 0.8

--- a/src/auto/algo_controller.py
+++ b/src/auto/algo_controller.py
@@ -57,9 +57,15 @@ class AlgoController:
 
         if mapping != self.last_mapping:
             reason = self.explain(mapping)
-            logging.getLogger().info(
-                f"Nuevo mapeo: {mapping}", extra={"kind": "algo_controller", "reason": reason}
+            msg = (
+                "mapping: entries_exits={entry}, risk_limits={risk}, sizing={size} (motivo: {reason})"
+            ).format(
+                entry=mapping.get("entries_exits"),
+                risk=mapping.get("risk_limits"),
+                size=mapping.get("position_sizing"),
+                reason=reason,
             )
+            logging.getLogger().info(msg, extra={"kind": "algo_controller"})
             self.last_mapping = mapping
         return mapping
 

--- a/src/auto/reward_tuner.py
+++ b/src/auto/reward_tuner.py
@@ -167,6 +167,12 @@ class RewardTuner:
         if not success:
             self.weights = prev_w
 
+        arrow = "↑" if direction == "up" else "↓"
+        delta_w = self.weights[key] - prev_w[key]
+        delta_score = score_after - score_before
+        msg = f"{key} {arrow} {delta_w:+.2f} (Δscore {delta_score:+.2f})"
+        logging.getLogger().info(msg, extra={"kind": "reward_tuner"})
+
         self.last_action = None
 
 

--- a/src/auto/stage_scheduler.py
+++ b/src/auto/stage_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict
@@ -93,6 +94,9 @@ class StageScheduler:
                         reason_parts.append(notes)
                     reason = ", ".join(reason_parts)
                     info = {"stage": self.stage, "prev": prev, "changed": True, "reason": reason}
+                    logging.getLogger().info(
+                        f"{prev} → {self.stage}", extra={"kind": "stage_scheduler"}
+                    )
                 else:
                     info = {"stage": self.stage, "changed": False}
             else:

--- a/src/policy/hybrid_runtime.py
+++ b/src/policy/hybrid_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import logging
 from src.auto import AlgoController
 
 
@@ -35,6 +36,15 @@ class HybridRuntime:
         action = signal
         if mapping.get("risk_limits") == "ppo" or mapping.get("position_sizing") == "ppo":
             action = self.ppo_control.filter(signal, obs)
+            if action != signal:
+                logging.getLogger().info(
+                    "control ajusta qty %s→%s price %s→%s",
+                    signal.get("qty"),
+                    action.get("qty"),
+                    signal.get("price"),
+                    action.get("price"),
+                    extra={"kind": "ppo_control"},
+                )
         return action
 
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -57,7 +57,10 @@ with st.sidebar:
     # Cargar YAML
     try:
         cfg = load_config(CONFIG_PATH)
+        defaults_used = cfg.pop("_defaults_used", [])
         paths.ensure_dirs_exist()
+        if defaults_used:
+            st.warning("Config incompleta; se aplicaron defaults para: " + ", ".join(defaults_used))
     except Exception as e:
         st.error(f"No se pudo cargar {CONFIG_PATH}: {e}")
         cfg = {}
@@ -657,7 +660,19 @@ if st.button("📈 Evaluar"):
     except Exception as e:
         st.error(f"Fallo al evaluar: {e}")
 st.subheader("Actividad en vivo")
-kind_options = ["trades", "riesgo", "datos", "checkpoints", "llm", "metricas", "reward_tuner"]
+kind_options = [
+    "trades",
+    "riesgo",
+    "datos",
+    "checkpoints",
+    "llm",
+    "metricas",
+    "reward_tuner",
+    "algo_controller",
+    "stage_scheduler",
+    "dqn_stability",
+    "ppo_control",
+]
 selected_kinds = st.multiselect("Tipos", kind_options, default=kind_options, key="log_kind_sel")
 
 if "log_paused" not in st.session_state:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,15 +1,45 @@
 from __future__ import annotations
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
+from pathlib import Path
+import copy
 import yaml
 from dotenv import load_dotenv
 
 
+def _deep_update(base: Dict[str, Any], upd: Dict[str, Any]) -> None:
+    for k, v in upd.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            _deep_update(base[k], v)
+        else:
+            base[k] = v
+
+
+def _find_missing(defaults: Dict[str, Any], cfg: Dict[str, Any], prefix: str = "") -> List[str]:
+    missing: List[str] = []
+    for k, v in defaults.items():
+        key = f"{prefix}{k}" if prefix else k
+        if k not in cfg:
+            missing.append(key)
+        elif isinstance(v, dict) and isinstance(cfg[k], dict):
+            missing.extend(_find_missing(v, cfg[k], key + "."))
+    return missing
+
+
 def load_config(path: str, overrides: Dict[str, Any] | None = None) -> Dict[str, Any]:
-    """Load YAML config and environment variables (.env) with overrides."""
+    """Load YAML config, merging with defaults and environment variables."""
     load_dotenv()
+
+    defaults_path = Path(__file__).resolve().parents[2] / "configs" / "default.yaml"
+    with open(defaults_path, "r", encoding="utf-8") as f:
+        defaults = yaml.safe_load(f) or {}
+
     with open(path, "r", encoding="utf-8") as f:
-        cfg = yaml.safe_load(f) or {}
+        user_cfg = yaml.safe_load(f) or {}
+
+    cfg = copy.deepcopy(defaults)
+    _deep_update(cfg, user_cfg)
+    cfg["_defaults_used"] = _find_missing(defaults, user_cfg)
 
     # Fill from env if present
     env_map = {

--- a/tests/test_algo_controller.py
+++ b/tests/test_algo_controller.py
@@ -1,0 +1,13 @@
+from src.auto import AlgoController
+
+
+def test_high_vol_and_td_error_mapping():
+    ctrl = AlgoController()
+    mapping = ctrl.decide(
+        {"intraminute": True},
+        {"volatility": 0.05},
+        {"td_error": 2.0},
+    )
+    assert mapping["entries_exits"] == "dqn"
+    assert mapping["risk_limits"] == "ppo"
+    assert mapping["position_sizing"] == "ppo"

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,0 +1,25 @@
+import yaml
+from src.utils.config import load_config
+
+
+def test_defaults_merge(tmp_path):
+    # Load current defaults and remove new keys to simulate older config
+    with open('configs/default.yaml', 'r', encoding='utf-8') as f:
+        base = yaml.safe_load(f)
+    old = base.copy()
+    for key in ['reward_tuner', 'hybrid', 'algo_controller', 'stage_scheduler']:
+        old.pop(key, None)
+    cfg_path = tmp_path / 'old.yaml'
+    with open(cfg_path, 'w', encoding='utf-8') as f:
+        yaml.safe_dump(old, f)
+
+    cfg = load_config(str(cfg_path))
+    defaults_used = cfg.get('_defaults_used', [])
+
+    assert cfg['reward_tuner']['enabled'] is True
+    assert cfg['hybrid']['enabled'] is True and cfg['hybrid']['train_both'] is True
+    assert cfg['algo_controller']['llm_enabled'] is False
+    assert cfg['stage_scheduler']['enabled'] is True
+
+    for key in ['reward_tuner', 'hybrid', 'algo_controller', 'stage_scheduler']:
+        assert key in defaults_used

--- a/tests/test_hybrid_runtime.py
+++ b/tests/test_hybrid_runtime.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.policy import HybridRuntime
+from src.auto import AlgoController
+
+
+class DummyDQN:
+    def act(self, obs):
+        return {"side": "buy", "qty": 0.05, "price": 100.0}
+
+
+class DummyPPO:
+    def __init__(self, min_notional, slippage):
+        self.min_notional = min_notional
+        self.slippage = slippage
+        self.act_called = False
+
+    def act(self, obs):
+        self.act_called = True
+        return {"side": "sell"}
+
+    def filter(self, signal, obs):
+        qty = max(signal["qty"], self.min_notional / signal["price"])
+        price = signal["price"] * (1 + self.slippage)
+        return {**signal, "qty": qty, "price": price}
+
+
+def test_hybrid_runtime_applies_control():
+    controller = AlgoController()
+    ppo = DummyPPO(min_notional=10.0, slippage=0.01)
+    runtime = HybridRuntime(DummyDQN(), ppo, controller)
+    action = runtime.act(
+        {"price": 100.0},
+        stage_info={"intraminute": True},
+        data_profile={"volatility": 0.05},
+        stability={"td_error": 2.0},
+    )
+    assert action["qty"] == pytest.approx(0.1)
+    assert action["price"] == pytest.approx(101.0)
+    assert action["side"] == "buy"
+    assert not ppo.act_called

--- a/tests/test_reward_tuner.py
+++ b/tests/test_reward_tuner.py
@@ -1,0 +1,36 @@
+import json
+import random
+from pathlib import Path
+
+from src.auto import RewardTuner
+
+
+def _ensure_bandit_valid(rt: RewardTuner) -> None:
+    """Adjust bandit arms to avoid zero-variance beta draws."""
+    for arms in rt.bandit.values():
+        for arm in arms.values():
+            arm.trials = arm.success + 1
+
+
+def test_propose_and_confirm(tmp_path):
+    random.seed(0)
+    mem = tmp_path / "mem.jsonl"
+    tuner = RewardTuner({"w_pnl": 1.0}, {"w_pnl": (0.5, 2.0)}, mem)
+    _ensure_bandit_valid(tuner)
+
+    before = dict(tuner.weights)
+    proposal = tuner.propose({"pnl": 1.0})
+    assert proposal["w_pnl"] != before["w_pnl"]
+
+    tuner.confirm({"pnl": 2.0})
+    assert tuner.weights["w_pnl"] == proposal["w_pnl"]
+    records = [json.loads(line) for line in mem.read_text().splitlines()]
+    assert records[-1]["success"] is True
+
+    _ensure_bandit_valid(tuner)
+    prev = dict(tuner.weights)
+    tuner.propose({"pnl": 1.0})
+    tuner.confirm({"pnl": -1.0})
+    assert tuner.weights["w_pnl"] == prev["w_pnl"]
+    records = [json.loads(line) for line in mem.read_text().splitlines()]
+    assert records[-1]["success"] is False


### PR DESCRIPTION
## Summary
- Merge configs with defaults to backfill new keys like `hybrid`, `algo_controller`, and `stage_scheduler`
- Warn in the Streamlit UI when missing config keys are auto-filled from defaults
- Test configuration loading to ensure defaults are applied without crashes

## Testing
- `pytest tests/test_reward_tuner.py tests/test_algo_controller.py tests/test_hybrid_runtime.py tests/test_config_defaults.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a55687a1448328897a9b746aba4379