### PR TITLE
Fix parquet atomic write and Streamlit rerun API

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -705,4 +705,4 @@ placeholder.text("\n".join(st.session_state.get("log_lines", [])))
 
 if not st.session_state["log_paused"]:
     time.sleep(0.5)
-    st.experimental_rerun()
+    st.rerun()


### PR DESCRIPTION
## Summary
- Ensure atomic parquet writes use fsync via file descriptor and ignore unsupported platforms
- Replace deprecated `st.experimental_rerun` with `st.rerun`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f90a8d648328af36e02e24c328f1