### PR TITLE
feat: automate symbol discovery

### DIFF
--- a/src/data/pipeline.py
+++ b/src/data/pipeline.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Callable, List
+
+from .ccxt_loader import get_exchange, fetch_ohlcv
+from .symbol_discovery import discover_symbols
+from .enrichment import fetch_symbol_metadata
+from .quality import validate_metadata, validate_ohlcv
+from .ensure import ensure_ohlcv
+from .incremental import update_all
+from .refresh_worker import start_refresh_worker
+
+
+def prepare_data(
+    auto_refresh: bool = True,
+    refresh_every_min: int = 5,
+    *,
+    progress_cb: Callable[[str], None] | None = None,
+    timeframe: str = "1m",
+    top_n: int = 20,
+) -> List[str]:
+    """Run the full data preparation pipeline and return discovered symbols."""
+
+    def report(msg: str) -> None:
+        if progress_cb:
+            progress_cb(msg)
+
+    ex = get_exchange()
+    report("Descubriendo…")
+    symbols = discover_symbols(ex, top_n=top_n)
+
+    report("Validando…")
+    meta = fetch_symbol_metadata(symbols)
+    for sym in symbols:
+        validate_metadata(meta.get(sym, {}))
+        df = fetch_ohlcv(ex, sym, timeframe)
+        validate_ohlcv(df)
+
+    report("Descargando…")
+    for sym in symbols:
+        ensure_ohlcv(ex.id if hasattr(ex, "id") else "binance", sym, timeframe)
+
+    report("Actualizando…")
+    update_all(symbols, timeframe)
+
+    if auto_refresh:
+        start_refresh_worker(symbols, timeframe, every=refresh_every_min)
+        report("Refresco en marcha ✔")
+    return symbols

--- a/src/data/refresh_worker.py
+++ b/src/data/refresh_worker.py
@@ -59,12 +59,14 @@ def _run(symbols: Iterable[str], timeframe: str, interval_min: float) -> None:
         _stop_event.wait(interval_min * 60)
 
 
-def start_refresh_worker(symbols: Iterable[str], timeframe_min: str) -> None:
+def start_refresh_worker(
+    symbols: Iterable[str], timeframe_min: str, every: float | None = None
+) -> None:
     """Start background thread to periodically refresh OHLCV data."""
     global _thread
     if _thread and _thread.is_alive():
         return
-    interval = _parse_interval(timeframe_min)
+    interval = every if every is not None else _parse_interval(timeframe_min)
     dataset_updated.clear()
     _stop_event.clear()
     _thread = threading.Thread(

--- a/src/data/symbol_discovery.py
+++ b/src/data/symbol_discovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List
+from datetime import datetime, UTC
 
 STABLES = {
     "USDT",
@@ -55,3 +56,29 @@ def discover_symbols(exchange, quote: str = "USDT", top_n: int = 20) -> List[str
 
     ranked.sort(reverse=True)
     return [sym for _, sym in ranked[:top_n]]
+
+
+def discover_summary(symbols: List[str]) -> str:
+    """Return a human readable summary for *symbols*.
+
+    Example::
+
+        "Top 15 por volumen USDT, excluidos stablecoins, actualizado 10:32 UTC"
+
+    Parameters
+    ----------
+    symbols:
+        List of symbol strings like ``"BTC/USDT"``.
+
+    Returns
+    -------
+    str
+        Summary describing the discovery outcome.
+    """
+
+    quote = symbols[0].split("/")[1] if symbols else "USDT"
+    now = datetime.now(UTC).strftime("%H:%M")
+    return (
+        f"Top {len(symbols)} por volumen {quote}, excluidos stablecoins, "
+        f"actualizado {now} UTC"
+    )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -9,21 +9,10 @@ from src.utils.config import load_config
 from src.utils import paths
 from src.reports.human_friendly import render_panel
 from src.utils.device import get_device, set_cpu_threads
-from src.data.ccxt_loader import get_exchange, save_history
-from src.data.ensure import ensure_ohlcv
-from src.data.volatility_windows import find_high_activity_windows
-from src.data.symbol_discovery import discover_symbols
-from src.data import (
-    fetch_symbol_metadata,
-    fetch_extra_series,
-    validate_symbols,
-    validate_ohlcv,
-    validate_metadata,
-    validate_trades,
-    passes,
-    summarize,
-)
-from src.data.quality import QualityReport
+from src.data.ccxt_loader import get_exchange
+from src.data.symbol_discovery import discover_symbols, discover_summary
+from src.data.pipeline import prepare_data
+from src.data import validate_symbols
 from src.exchange.binance_meta import BinanceMeta
 from dotenv import load_dotenv
 from src.auto.strategy_selector import choose_algo
@@ -73,27 +62,15 @@ with st.sidebar:
     mode = st.radio("Modo", ["Mainnet", "Testnet"], index=1 if use_testnet_default else 0)
     use_testnet = mode == "Testnet"
     os.environ["BINANCE_USE_TESTNET"] = "true" if use_testnet else "false"
-    st.caption("Símbolos sugeridos (auto)")
-    refresh_syms = st.button("Actualizar", key="refresh_syms")
-    if "symbol_checks" not in st.session_state or refresh_syms:
-        try:
-            ex = get_exchange(use_testnet=use_testnet)
-            suggested = discover_symbols(ex, top_n=20)
-        except Exception as e:
-            st.warning(f"Descubrimiento falló: {e}")
-            suggested = cfg.get("symbols") or ["BTC/USDT"]
-        checks = st.session_state.get("symbol_checks", {})
-        for s in suggested:
-            checks.setdefault(s, True)
-        st.session_state["symbol_checks"] = checks
-    checks = st.session_state.get("symbol_checks", {})
-    for sym in sorted(checks):
-        checks[sym] = st.checkbox(sym, value=checks[sym], key=f"sym_{sym}")
-    manual = st.text_input("Añadir manualmente", key="manual_sym").upper().strip()
-    if manual and manual not in checks:
-        checks[manual] = True
-    selected_symbols = [s for s, v in checks.items() if v]
+    try:
+        ex = get_exchange(use_testnet=use_testnet)
+        selected_symbols = discover_symbols(ex, top_n=20)
+    except Exception as e:
+        st.warning(f"Descubrimiento falló: {e}")
+        selected_symbols = cfg.get("symbols") or ["BTC/USDT"]
     cfg["symbols"] = selected_symbols
+    st.caption(discover_summary(selected_symbols))
+    st.code("\n".join(selected_symbols))
 
     fees_dict = cfg.get("fees", {})
     default_fee_taker = float(fees_dict.get("taker", 0.001))
@@ -435,181 +412,18 @@ if invalid_syms:
 selected_symbols = selected_valid
 cfg["symbols"] = selected_valid
 
-st.subheader("🧹 Enriquecimiento y verificación de datos")
-st.caption(
-    "Descarga datos iniciales y los valida. Usa '🔄 Actualizar datos' para traer solo nuevos registros."
-)
-if st.button("Obtener y validar datos"):
-    from pathlib import Path
-    from datetime import datetime
-
-    st.session_state["busy"] = True
-    try:
-        with st.spinner("Descargando y validando..."):
-            ex = get_exchange(use_testnet=use_testnet)
-            # Re-descubrir por si hay nuevos símbolos disponibles
-            try:
-                discover_symbols(ex, top_n=5)
-            except Exception:
-                pass
-            if invalid_syms:
-                st.warning(
-                    "Ignorando símbolos inválidos: "
-                    + ", ".join(i["symbol"] for i in invalid_syms)
-                )
-
-            meta_map = fetch_symbol_metadata(selected_symbols)
-            for sym in selected_symbols:
-                meta = meta_map.get(sym, {})
-                m_report = validate_metadata(meta)
-                series = fetch_extra_series(sym, timeframe=cfg.get("timeframe", "1m"))
-                ohlcv = series.get("ohlcv")
-                t_report = validate_trades(series.get("trades"))
-                o_report = validate_ohlcv(ohlcv)
-                combined = QualityReport()
-                combined.errors.extend(m_report.errors + o_report.errors + t_report.errors)
-                combined.warnings.extend(
-                    m_report.warnings + o_report.warnings + t_report.warnings
-                )
-                summary = summarize(combined)
-                if passes(combined):
-                    out_dir = Path("data/processed") / sym.replace("/", "")
-                    out_dir.mkdir(parents=True, exist_ok=True)
-                    data_file = ""
-                    if ohlcv is not None and not ohlcv.empty:
-                        try:
-                            ohlcv.reset_index().to_parquet(
-                                out_dir / "ohlcv.parquet", index=False
-                            )
-                            data_file = "ohlcv.parquet"
-                        except Exception:
-                            ohlcv.reset_index().to_csv(
-                                out_dir / "ohlcv.csv", index=False
-                            )
-                            data_file = "ohlcv.csv"
-                    manifest = {
-                        "symbol": sym,
-                        "obtained_at": datetime.now(UTC).isoformat(),
-                        "source": meta.get("source"),
-                        "qc": summary,
-                        "data_file": data_file,
-                    }
-                    if meta.get("error"):
-                        manifest["note"] = meta["error"]
-                    with open(out_dir / "manifest.json", "w", encoding="utf-8") as f:
-                        json.dump(manifest, f, indent=2)
-                    st.success(f"✅ {sym} - {summary}")
-                else:
-                    st.error(f"❌ {sym} - {summary}")
-        st.success("Proceso completado")
-    except BaseException as err:
-        if isinstance(err, Exception):
-            st.error(f"Error: {err}")
-        else:
-            st.warning("Proceso cancelado")
-    finally:
-        st.session_state["busy"] = False
-
 st.subheader("📥 Datos")
-st.caption("La precisión se elige automáticamente al mínimo disponible; el modelo puede reagrupar internamente")
-st.write("Construyendo dataset con tramos de alta actividad...")
-st.write("Seleccionados: " + ", ".join(selected_symbols))
-if st.button("🔄 Actualizar datos"):
-    from datetime import datetime, UTC, timedelta
-    import json
-    from src.data.incremental import (
-        last_watermark,
-        fetch_ohlcv_incremental,
-        upsert_parquet,
-    )
+if st.button("Preparar datos (auto)"):
+    status = st.status("Descubriendo…", expanded=True)
 
-    st.session_state["busy"] = True
-    try:
-        ex = get_exchange(use_testnet=use_testnet)
-        tf_str = cfg.get("timeframe", "1m")
-        for sym in selected_symbols:
-            since = last_watermark(sym, tf_str)
-            if since is None:
-                since = int((datetime.now(UTC) - timedelta(days=30)).timestamp() * 1000)
-            df_new = fetch_ohlcv_incremental(ex, sym, tf_str, since_ms=since)
-            if df_new.empty:
-                st.info(f"{sym}: sin datos nuevos")
-                continue
-            path = paths.raw_parquet_path(ex.id if hasattr(ex, "id") else "binance", sym, tf_str)
-            upsert_parquet(df_new, path)
-            manifest = {
-                "symbol": sym,
-                "timeframe": tf_str,
-                "watermark": int(df_new["ts"].max()),
-                "obtained_at": datetime.now(UTC).isoformat(),
-            }
-            with open(path.with_suffix(".manifest.json"), "w", encoding="utf-8") as f:
-                json.dump(manifest, f, indent=2)
-            st.success(f"{sym} actualizado")
-    except BaseException as err:
-        if isinstance(err, Exception):
-            st.error(f"Error: {err}")
-        else:
-            st.warning("Proceso cancelado")
-    finally:
-        st.session_state["busy"] = False
+    def _report(msg: str) -> None:
+        status.update(label=msg)
 
-if st.button("⬇️ Descargar histórico"):
-    from datetime import datetime
-    import pandas as pd
-    st.session_state["busy"] = True
     try:
-        if invalid_syms:
-            st.warning(
-                "Ignorando símbolos inválidos: "
-                + ", ".join(i["symbol"] for i in invalid_syms)
-            )
-        tf_str = cfg.get("timeframe", "1m")
-        timeframe_min = int(tf_str.rstrip("m"))
-        st.info("Construyendo dataset con tramos de alta actividad...")
-        windows, lookback_h = find_high_activity_windows(
-            selected_symbols, timeframe_min
-        )
-        if windows:
-            st.write("Ventanas ejemplo:")
-            for s, e in windows[:5]:
-                st.write(
-                    f"{datetime.fromtimestamp(s/1000, UTC)} → {datetime.fromtimestamp(e/1000, UTC)}"
-                )
-        total_hours = sum((e - s) // 3600000 for s, e in windows)
-        st.info(f"Ventanas total: {total_hours}h")
-        ex = get_exchange(use_testnet=use_testnet)
-        for sym in selected_symbols:
-            try:
-                path = ensure_ohlcv(
-                    ex.id if hasattr(ex, "id") else "binance",
-                    sym,
-                    tf_str,
-                    hours=lookback_h,
-                )
-                df = pd.read_parquet(path)
-                parts = [df[(df.ts >= s) & (df.ts < e)] for s, e in windows]
-                if parts:
-                    merged = pd.concat(parts)
-                    tf = tf_str
-                    cfg["timeframe"] = tf
-                    out = save_history(
-                        merged,
-                        paths.RAW_DIR,
-                        ex.id if hasattr(ex, "id") else "binance",
-                        sym,
-                        tf,
-                    )
-                    st.success(f"Guardado: {out}")
-            except Exception as err:
-                st.warning(f"Fallo {sym}: {err}")
-    except BaseException as err:
-        if isinstance(err, Exception):
-            st.error(f"Error en descarga: {err}")
-        else:
-            st.warning("Proceso cancelado")
-    finally:
-        st.session_state["busy"] = False
+        prepare_data(progress_cb=_report)
+        status.update(label="Refresco en marcha ✔", state="complete")
+    except Exception as err:
+        status.update(label=f"Error: {err}", state="error")
 
 st.subheader("🧠 Entrenamiento")
 colt1, colt2 = st.columns(2)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,57 @@
+import pandas as pd
+
+from src.data import pipeline
+
+
+def test_prepare_data_runs_all(monkeypatch):
+    calls = []
+
+    def fake_discover(ex, top_n=20):
+        calls.append("discover")
+        return ["BTC/USDT"]
+
+    def fake_meta(symbols):
+        calls.append("meta")
+        return {"BTC/USDT": {}}
+
+    def fake_validate_meta(meta):
+        calls.append("v_meta")
+
+    def fake_fetch_ohlcv(ex, sym, tf):
+        calls.append("fetch")
+        return pd.DataFrame()
+
+    def fake_validate_ohlcv(df):
+        calls.append("v_ohlcv")
+
+    def fake_ensure(exch, sym, tf):
+        calls.append("ensure")
+
+    def fake_update(symbols, timeframe):
+        calls.append("update")
+
+    def fake_start(symbols, timeframe, every=5):
+        calls.append("start")
+
+    monkeypatch.setattr(pipeline, "discover_symbols", fake_discover)
+    monkeypatch.setattr(pipeline, "fetch_symbol_metadata", fake_meta)
+    monkeypatch.setattr(pipeline, "validate_metadata", fake_validate_meta)
+    monkeypatch.setattr(pipeline, "fetch_ohlcv", fake_fetch_ohlcv)
+    monkeypatch.setattr(pipeline, "validate_ohlcv", fake_validate_ohlcv)
+    monkeypatch.setattr(pipeline, "ensure_ohlcv", fake_ensure)
+    monkeypatch.setattr(pipeline, "update_all", fake_update)
+    monkeypatch.setattr(pipeline, "start_refresh_worker", fake_start)
+    monkeypatch.setattr(pipeline, "get_exchange", lambda: None)
+
+    pipeline.prepare_data()
+
+    assert calls == [
+        "discover",
+        "meta",
+        "v_meta",
+        "fetch",
+        "v_ohlcv",
+        "ensure",
+        "update",
+        "start",
+    ]

--- a/tests/test_symbol_discovery.py
+++ b/tests/test_symbol_discovery.py
@@ -1,4 +1,4 @@
-from src.data.symbol_discovery import discover_symbols
+from src.data.symbol_discovery import discover_symbols, discover_summary
 
 
 class DummyEx:
@@ -30,3 +30,12 @@ def test_discover_symbols_filters_and_sorts():
         "BNB/USDT",
         "LTC/USDT",
     ]
+
+
+def test_discover_summary_format():
+    syms = ["BTC/USDT", "ETH/USDT"]
+    summary = discover_summary(syms)
+    assert summary.startswith(
+        "Top 2 por volumen USDT, excluidos stablecoins, actualizado"
+    )
+    assert summary.endswith("UTC")


### PR DESCRIPTION
## Summary
- add discover_summary helper for readable symbol stats
- apply auto-discovered symbols in Streamlit app with read-only display
- test symbol discovery summary format
- orchestrate full data preparation pipeline and start background refresh
- simplify UI to single 'Preparar datos' button showing pipeline progress

## Testing
- `pytest tests/test_symbol_discovery.py -q`
- `pytest tests/test_pipeline.py -q`
- `pytest tests/test_refresh_worker.py tests/test_incremental.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a645e24ecc8328a5e03e706e673aaa