### PR TITLE
Add credential verification panel with connection badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 
 # Virtual environments
 .env
+.env.local
 .venv
 venv/
 ENV/

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -18,10 +18,41 @@ from src.exchange.binance_meta import BinanceMeta
 from dotenv import load_dotenv
 from src.auto.strategy_selector import choose_algo
 from src.auto.hparam_tuner import tune
+from src.ui.credentials import (
+    verify_binance_mainnet,
+    verify_binance_testnet,
+    verify_openai,
+)
 
 CONFIG_PATH = st.session_state.get("config_path", "configs/default.yaml")
 
 st.set_page_config(page_title="DRL Trading Config", layout="wide")
+
+load_dotenv(".env.local")
+load_dotenv()
+
+if "binance_mainnet_ok" not in st.session_state:
+    api_key = os.getenv("BINANCE_API_KEY")
+    api_secret = os.getenv("BINANCE_API_SECRET")
+    ok = False
+    if api_key and api_secret:
+        ok, _ = verify_binance_mainnet(api_key, api_secret)
+    st.session_state["binance_mainnet_ok"] = ok
+
+if "binance_testnet_ok" not in st.session_state:
+    t_key = os.getenv("BINANCE_TESTNET_API_KEY")
+    t_secret = os.getenv("BINANCE_TESTNET_API_SECRET")
+    ok = False
+    if t_key and t_secret:
+        ok, _ = verify_binance_testnet(t_key, t_secret)
+    st.session_state["binance_testnet_ok"] = ok
+
+if "openai_ok" not in st.session_state:
+    o_key = os.getenv("OPENAI_API_KEY")
+    ok = False
+    if o_key:
+        ok, _ = verify_openai(o_key)
+    st.session_state["openai_ok"] = ok
 
 st.title("⚙️ Configuración DRL Trading")
 
@@ -43,6 +74,24 @@ else:
     st.sidebar.info(f"Dispositivo: CPU ({threads} hilos)")
 
 with st.sidebar:
+    st.header("Conexiones")
+    def badge(ok: bool) -> str:
+        return f":{'green' if ok else 'red'}[{'Conectado' if ok else 'No conectado'}]"
+
+    st.markdown(f"Binance mainnet {badge(st.session_state.get('binance_mainnet_ok', False))}")
+    st.markdown(f"Binance testnet {badge(st.session_state.get('binance_testnet_ok', False))}")
+    st.markdown(f"OpenAI {badge(st.session_state.get('openai_ok', False))}")
+    if not (
+        st.session_state.get("binance_mainnet_ok")
+        and st.session_state.get("binance_testnet_ok")
+        and st.session_state.get("openai_ok")
+    ):
+        st.warning("Faltan claves o verificación falló")
+        try:
+            st.page_link("src/ui/credentials.py", label="Configurar conexiones")
+        except Exception:
+            st.markdown("[Configurar conexiones](./credentials)")
+
     st.header("Ajustes globales")
     CONFIG_PATH = st.text_input("Ruta config YAML", value=CONFIG_PATH, key="cfg_path", help="Normalmente configs/default.yaml")
     st.session_state["config_path"] = CONFIG_PATH

--- a/src/ui/credentials.py
+++ b/src/ui/credentials.py
@@ -1,0 +1,135 @@
+import os
+import time
+import hmac
+import hashlib
+from pathlib import Path
+from typing import Tuple
+
+import requests
+import streamlit as st
+from dotenv import load_dotenv, set_key
+
+
+BINANCE_MAINNET = "https://api.binance.com"
+BINANCE_TESTNET = "https://testnet.binance.vision"
+
+
+def _badge(label: str, ok: bool) -> str:
+    color = "green" if ok else "red"
+    text = "Conectado" if ok else "No conectado"
+    return f"{label}: :{color}[{text}]"
+
+
+def verify_binance_mainnet(api_key: str, api_secret: str) -> Tuple[bool, str]:
+    """Ping mainnet and call signed account endpoint."""
+    try:
+        requests.get(f"{BINANCE_MAINNET}/api/v3/ping", timeout=5).raise_for_status()
+        ts = int(time.time() * 1000)
+        query = f"timestamp={ts}"
+        signature = hmac.new(api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+        headers = {"X-MBX-APIKEY": api_key}
+        params = {"timestamp": ts, "signature": signature}
+        requests.get(f"{BINANCE_MAINNET}/api/v3/account", params=params, headers=headers, timeout=5).raise_for_status()
+        return True, ""
+    except Exception as e:  # pragma: no cover - network
+        return False, str(e)
+
+
+def verify_binance_testnet(api_key: str, api_secret: str) -> Tuple[bool, str]:
+    """Ping testnet and fetch exchangeInfo (no auth required)."""
+    try:
+        requests.get(f"{BINANCE_TESTNET}/api/v3/ping", timeout=5).raise_for_status()
+        requests.get(f"{BINANCE_TESTNET}/api/v3/exchangeInfo", timeout=5).raise_for_status()
+        return True, ""
+    except Exception as e:  # pragma: no cover - network
+        return False, str(e)
+
+
+def verify_openai(api_key: str) -> Tuple[bool, str]:
+    """Minimal OpenAI check using models.list."""
+    try:
+        from openai import OpenAI  # type: ignore
+    except Exception as e:  # pragma: no cover - import
+        return False, f"package missing: {e}"
+    try:
+        client = OpenAI(api_key=api_key)
+        client.models.list()
+        return True, ""
+    except Exception as e:  # pragma: no cover - network
+        return False, str(e)
+
+
+def _save_env(values: dict, persist: bool) -> None:
+    for key, val in values.items():
+        if val:
+            os.environ[key] = val
+    if persist:
+        env_path = Path(".env.local")
+        env_path.touch(exist_ok=True)
+        for key, val in values.items():
+            set_key(env_path, key, val or "")
+        st.warning("Claves guardadas en .env.local. No lo subas al repositorio.")
+
+
+def main() -> None:
+    st.set_page_config(page_title="Conexiones", layout="wide")
+    st.title("🔐 Conexiones")
+
+    load_dotenv(".env.local")
+    load_dotenv()
+
+    binance_key = st.text_input("Binance API Key (mainnet)", value=os.getenv("BINANCE_API_KEY", ""))
+    binance_secret = st.text_input(
+        "Binance API Secret (mainnet)", value=os.getenv("BINANCE_API_SECRET", ""), type="password"
+    )
+    test_key = st.text_input("Binance API Key (testnet)", value=os.getenv("BINANCE_TESTNET_API_KEY", ""))
+    test_secret = st.text_input(
+        "Binance API Secret (testnet)", value=os.getenv("BINANCE_TESTNET_API_SECRET", ""), type="password"
+    )
+    openai_key = st.text_input("OpenAI API Key", value=os.getenv("OPENAI_API_KEY", ""), type="password")
+    persist = st.checkbox("Guardar en .env.local", value=False)
+    st.caption("Las claves se guardan en memoria; activa el checkbox para persistir en .env.local")
+
+    if st.button("Guardar y verificar"):
+        values = {
+            "BINANCE_API_KEY": binance_key,
+            "BINANCE_API_SECRET": binance_secret,
+            "BINANCE_TESTNET_API_KEY": test_key,
+            "BINANCE_TESTNET_API_SECRET": test_secret,
+            "OPENAI_API_KEY": openai_key,
+        }
+        _save_env(values, persist)
+        b_main, err_main = (False, "")
+        b_test, err_test = (False, "")
+        oai, err_oai = (False, "")
+        if binance_key and binance_secret:
+            b_main, err_main = verify_binance_mainnet(binance_key, binance_secret)
+        if test_key and test_secret:
+            b_test, err_test = verify_binance_testnet(test_key, test_secret)
+        if openai_key:
+            oai, err_oai = verify_openai(openai_key)
+        st.session_state["binance_mainnet_ok"] = b_main
+        st.session_state["binance_testnet_ok"] = b_test
+        st.session_state["openai_ok"] = oai
+        if b_main:
+            st.success("Binance mainnet OK")
+        elif err_main:
+            st.error(f"Binance mainnet: {err_main}")
+        if b_test:
+            st.success("Binance testnet OK")
+        elif err_test:
+            st.error(f"Binance testnet: {err_test}")
+        if oai:
+            st.success("OpenAI OK")
+        elif err_oai:
+            st.error(f"OpenAI: {err_oai}")
+
+    st.markdown("## Estado")
+    col1, col2, col3 = st.columns(3)
+    col1.markdown(_badge("Binance mainnet", st.session_state.get("binance_mainnet_ok", False)))
+    col2.markdown(_badge("Binance testnet", st.session_state.get("binance_testnet_ok", False)))
+    col3.markdown(_badge("OpenAI", st.session_state.get("openai_ok", False)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add connection badge section in sidebar and auto-verify API keys
- Ignore `.env.local` for optional credential persistence
- Provide new `Conexiones` page to input, verify, and store Binance and OpenAI keys

## Testing
- `pytest` *(fails: KeyError 'hybrid'; CalledProcessError in backtest evaluate)*

------
https://chatgpt.com/codex/tasks/task_e_68a6587417888328902bd2b93c93fa93