### PR TITLE
Add credential verification panel with connection badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 
 # Virtual environments
 .env
+.env.local
 .venv
 venv/
 ENV/

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,7 +1,7 @@
-import os, io, sys, json, subprocess, time, uuid
+import os, io, sys, json, subprocess, time, uuid, shutil
 from datetime import datetime, UTC
 import streamlit as st
-from src.ui.log_stream import subscribe as log_subscribe, get_auto_profile
+from src.ui.log_stream import subscribe as log_subscribe, get_auto_profile, recent_counts
 from pathlib import Path
 from src.auto import reward_human_names, AlgoController
 from src.ui.tasks import run_bg, poll, set_progress
@@ -18,10 +18,41 @@ from src.exchange.binance_meta import BinanceMeta
 from dotenv import load_dotenv
 from src.auto.strategy_selector import choose_algo
 from src.auto.hparam_tuner import tune
+from src.ui.credentials import (
+    verify_binance_mainnet,
+    verify_binance_testnet,
+    verify_openai,
+)
 
 CONFIG_PATH = st.session_state.get("config_path", "configs/default.yaml")
 
 st.set_page_config(page_title="DRL Trading Config", layout="wide")
+
+load_dotenv(".env.local")
+load_dotenv()
+
+if "binance_mainnet_ok" not in st.session_state:
+    api_key = os.getenv("BINANCE_API_KEY")
+    api_secret = os.getenv("BINANCE_API_SECRET")
+    ok = False
+    if api_key and api_secret:
+        ok, _ = verify_binance_mainnet(api_key, api_secret)
+    st.session_state["binance_mainnet_ok"] = ok
+
+if "binance_testnet_ok" not in st.session_state:
+    t_key = os.getenv("BINANCE_TESTNET_API_KEY")
+    t_secret = os.getenv("BINANCE_TESTNET_API_SECRET")
+    ok = False
+    if t_key and t_secret:
+        ok, _ = verify_binance_testnet(t_key, t_secret)
+    st.session_state["binance_testnet_ok"] = ok
+
+if "openai_ok" not in st.session_state:
+    o_key = os.getenv("OPENAI_API_KEY")
+    ok = False
+    if o_key:
+        ok, _ = verify_openai(o_key)
+    st.session_state["openai_ok"] = ok
 
 st.title("⚙️ Configuración DRL Trading")
 
@@ -41,8 +72,35 @@ if device == "cuda":
 else:
     threads = set_cpu_threads()
     st.sidebar.info(f"Dispositivo: CPU ({threads} hilos)")
+    if shutil.which("nvidia-smi"):
+        try:
+            res = subprocess.run(["nvidia-smi"], capture_output=True)
+            if res.returncode == 0:
+                st.sidebar.warning(
+                    "Se detectó GPU pero PyTorch no tiene soporte CUDA; considera reinstalarlo con CUDA."
+                )
+        except Exception:
+            pass
 
 with st.sidebar:
+    st.header("Conexiones")
+    def badge(ok: bool) -> str:
+        return f":{'green' if ok else 'red'}[{'Conectado' if ok else 'No conectado'}]"
+
+    st.markdown(f"Binance mainnet {badge(st.session_state.get('binance_mainnet_ok', False))}")
+    st.markdown(f"Binance testnet {badge(st.session_state.get('binance_testnet_ok', False))}")
+    st.markdown(f"OpenAI {badge(st.session_state.get('openai_ok', False))}")
+    if not (
+        st.session_state.get("binance_mainnet_ok")
+        and st.session_state.get("binance_testnet_ok")
+        and st.session_state.get("openai_ok")
+    ):
+        st.warning("Faltan claves o verificación falló")
+        try:
+            st.page_link("src/ui/credentials.py", label="Configurar conexiones")
+        except Exception:
+            st.markdown("[Configurar conexiones](./credentials)")
+
     st.header("Ajustes globales")
     CONFIG_PATH = st.text_input("Ruta config YAML", value=CONFIG_PATH, key="cfg_path", help="Normalmente configs/default.yaml")
     st.session_state["config_path"] = CONFIG_PATH
@@ -498,6 +556,10 @@ if st.button("🚀 Entrenar"):
                 st.error(f"Fallo al entrenar: {e}")
 
         log_box = st.empty()
+        progress_bar = st.progress(0.0)
+        progress_stats = st.empty()
+        target_steps = int(1_000_000)
+        stage = "training"
         thread = threading.Thread(target=_run_train, daemon=True)
         thread.start()
         lines: list[str] = []
@@ -505,8 +567,17 @@ if st.button("🚀 Entrenar"):
         while thread.is_alive():
             try:
                 entry = next(log_iter)
-                lines.append(f"[{entry['kind']}] {entry['message']}")
+                msg = entry["message"]
+                lines.append(f"[{entry['kind']}] {msg}")
                 log_box.code("\n".join(lines[-200:]))
+                if msg.startswith("[heartbeat]"):
+                    parts = dict(p.split("=") for p in msg.replace("[heartbeat]", "").strip().split())
+                    steps = int(parts.get("steps", 0))
+                    reward = float(parts.get("reward_mean", 0.0))
+                    progress_bar.progress(min(steps / target_steps, 1.0))
+                    progress_stats.text(
+                        f"Etapa: {stage} | Pasos: {steps}/{target_steps} | Reward medio: {reward:.4f}"
+                    )
             except Exception:
                 pass
         thread.join()
@@ -514,7 +585,16 @@ if st.button("🚀 Entrenar"):
         for _ in range(50):
             try:
                 entry = next(log_iter)
-                lines.append(f"[{entry['kind']}] {entry['message']}")
+                msg = entry["message"]
+                lines.append(f"[{entry['kind']}] {msg}")
+                if msg.startswith("[heartbeat]"):
+                    parts = dict(p.split("=") for p in msg.replace("[heartbeat]", "").strip().split())
+                    steps = int(parts.get("steps", 0))
+                    reward = float(parts.get("reward_mean", 0.0))
+                    progress_bar.progress(min(steps / target_steps, 1.0))
+                    progress_stats.text(
+                        f"Etapa: {stage} | Pasos: {steps}/{target_steps} | Reward medio: {reward:.4f}"
+                    )
             except Exception:
                 break
         log_box.code("\n".join(lines[-200:]))
@@ -581,6 +661,9 @@ if st.button("📈 Evaluar"):
 # ---- Registro por áreas ---------------------------------------------------
 
 st.subheader("Registro")
+total_events, kind_counts = recent_counts()
+parts = ", ".join(f"{k} {v}" for k, v in kind_counts.items())
+st.caption(f"Últimos 30s: {total_events} eventos ({parts})")
 
 AREA_KINDS = {
     "Datos": {"datos", "incremental_update", "qc"},

--- a/src/ui/credentials.py
+++ b/src/ui/credentials.py
@@ -1,0 +1,135 @@
+import os
+import time
+import hmac
+import hashlib
+from pathlib import Path
+from typing import Tuple
+
+import requests
+import streamlit as st
+from dotenv import load_dotenv, set_key
+
+
+BINANCE_MAINNET = "https://api.binance.com"
+BINANCE_TESTNET = "https://testnet.binance.vision"
+
+
+def _badge(label: str, ok: bool) -> str:
+    color = "green" if ok else "red"
+    text = "Conectado" if ok else "No conectado"
+    return f"{label}: :{color}[{text}]"
+
+
+def verify_binance_mainnet(api_key: str, api_secret: str) -> Tuple[bool, str]:
+    """Ping mainnet and call signed account endpoint."""
+    try:
+        requests.get(f"{BINANCE_MAINNET}/api/v3/ping", timeout=5).raise_for_status()
+        ts = int(time.time() * 1000)
+        query = f"timestamp={ts}"
+        signature = hmac.new(api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+        headers = {"X-MBX-APIKEY": api_key}
+        params = {"timestamp": ts, "signature": signature}
+        requests.get(f"{BINANCE_MAINNET}/api/v3/account", params=params, headers=headers, timeout=5).raise_for_status()
+        return True, ""
+    except Exception as e:  # pragma: no cover - network
+        return False, str(e)
+
+
+def verify_binance_testnet(api_key: str, api_secret: str) -> Tuple[bool, str]:
+    """Ping testnet and fetch exchangeInfo (no auth required)."""
+    try:
+        requests.get(f"{BINANCE_TESTNET}/api/v3/ping", timeout=5).raise_for_status()
+        requests.get(f"{BINANCE_TESTNET}/api/v3/exchangeInfo", timeout=5).raise_for_status()
+        return True, ""
+    except Exception as e:  # pragma: no cover - network
+        return False, str(e)
+
+
+def verify_openai(api_key: str) -> Tuple[bool, str]:
+    """Minimal OpenAI check using models.list."""
+    try:
+        from openai import OpenAI  # type: ignore
+    except Exception as e:  # pragma: no cover - import
+        return False, f"package missing: {e}"
+    try:
+        client = OpenAI(api_key=api_key)
+        client.models.list()
+        return True, ""
+    except Exception as e:  # pragma: no cover - network
+        return False, str(e)
+
+
+def _save_env(values: dict, persist: bool) -> None:
+    for key, val in values.items():
+        if val:
+            os.environ[key] = val
+    if persist:
+        env_path = Path(".env.local")
+        env_path.touch(exist_ok=True)
+        for key, val in values.items():
+            set_key(env_path, key, val or "")
+        st.warning("Claves guardadas en .env.local. No lo subas al repositorio.")
+
+
+def main() -> None:
+    st.set_page_config(page_title="Conexiones", layout="wide")
+    st.title("🔐 Conexiones")
+
+    load_dotenv(".env.local")
+    load_dotenv()
+
+    binance_key = st.text_input("Binance API Key (mainnet)", value=os.getenv("BINANCE_API_KEY", ""))
+    binance_secret = st.text_input(
+        "Binance API Secret (mainnet)", value=os.getenv("BINANCE_API_SECRET", ""), type="password"
+    )
+    test_key = st.text_input("Binance API Key (testnet)", value=os.getenv("BINANCE_TESTNET_API_KEY", ""))
+    test_secret = st.text_input(
+        "Binance API Secret (testnet)", value=os.getenv("BINANCE_TESTNET_API_SECRET", ""), type="password"
+    )
+    openai_key = st.text_input("OpenAI API Key", value=os.getenv("OPENAI_API_KEY", ""), type="password")
+    persist = st.checkbox("Guardar en .env.local", value=False)
+    st.caption("Las claves se guardan en memoria; activa el checkbox para persistir en .env.local")
+
+    if st.button("Guardar y verificar"):
+        values = {
+            "BINANCE_API_KEY": binance_key,
+            "BINANCE_API_SECRET": binance_secret,
+            "BINANCE_TESTNET_API_KEY": test_key,
+            "BINANCE_TESTNET_API_SECRET": test_secret,
+            "OPENAI_API_KEY": openai_key,
+        }
+        _save_env(values, persist)
+        b_main, err_main = (False, "")
+        b_test, err_test = (False, "")
+        oai, err_oai = (False, "")
+        if binance_key and binance_secret:
+            b_main, err_main = verify_binance_mainnet(binance_key, binance_secret)
+        if test_key and test_secret:
+            b_test, err_test = verify_binance_testnet(test_key, test_secret)
+        if openai_key:
+            oai, err_oai = verify_openai(openai_key)
+        st.session_state["binance_mainnet_ok"] = b_main
+        st.session_state["binance_testnet_ok"] = b_test
+        st.session_state["openai_ok"] = oai
+        if b_main:
+            st.success("Binance mainnet OK")
+        elif err_main:
+            st.error(f"Binance mainnet: {err_main}")
+        if b_test:
+            st.success("Binance testnet OK")
+        elif err_test:
+            st.error(f"Binance testnet: {err_test}")
+        if oai:
+            st.success("OpenAI OK")
+        elif err_oai:
+            st.error(f"OpenAI: {err_oai}")
+
+    st.markdown("## Estado")
+    col1, col2, col3 = st.columns(3)
+    col1.markdown(_badge("Binance mainnet", st.session_state.get("binance_mainnet_ok", False)))
+    col2.markdown(_badge("Binance testnet", st.session_state.get("binance_testnet_ok", False)))
+    col3.markdown(_badge("OpenAI", st.session_state.get("openai_ok", False)))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ui/log_stream.py
+++ b/src/ui/log_stream.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 import logging
 import time
-from collections import deque
-from datetime import datetime, UTC
-from typing import Deque, Dict, Iterator, Optional, Set
+from collections import defaultdict, deque
+from datetime import datetime, UTC, timedelta
+from typing import Deque, Dict, Iterator, Optional, Set, Tuple
 
 from src.reports.human_friendly import episode_sentence
 
-_LOG_BUFFER: Deque[Dict[str, object]] = deque(maxlen=1000)
+MAX_PER_KIND = 200
+_LOG_BUFFER: Deque[Dict[str, object]] = deque()
+_KIND_BUFFERS: Dict[str, Deque[Dict[str, object]]] = defaultdict(deque)
+_COALESCE: Dict[str, Dict[str, object]] = {}
 
 _EVENT_MAP = {
     "trade_executed": (
@@ -48,7 +51,40 @@ class _StreamHandler(logging.Handler):
         else:
             msg = record.getMessage()
             kind = getattr(record, "kind", event) or "general"
-        _LOG_BUFFER.append(
+
+        if event == "slippage_est":
+            state = _COALESCE.setdefault(
+                "slippage_est",
+                {
+                    "count": 0,
+                    "min_pct": None,
+                    "max_pct": None,
+                    "level": record.levelname.lower(),
+                    "levelno": record.levelno,
+                },
+            )
+            pct = getattr(record, "pct", 0.0)
+            state["count"] += 1
+            state["min_pct"] = pct if state["min_pct"] is None else min(state["min_pct"], pct)
+            state["max_pct"] = pct if state["max_pct"] is None else max(state["max_pct"], pct)
+            if state["count"] >= 20:
+                msg = (
+                    f"slippage_est x{state['count']}, rango "
+                    f"[{state['min_pct']:.2%}–{state['max_pct']:.2%}]"
+                )
+                _append_event(
+                    {
+                        "time": datetime.fromtimestamp(record.created, UTC),
+                        "level": state["level"],
+                        "levelno": state["levelno"],
+                        "kind": "datos",
+                        "message": msg,
+                    }
+                )
+                _COALESCE.pop("slippage_est", None)
+            return
+
+        _append_event(
             {
                 "time": datetime.fromtimestamp(record.created, UTC),
                 "level": record.levelname.lower(),
@@ -74,6 +110,8 @@ def subscribe(level: str = "info", kinds: Optional[Set[str]] = None) -> Iterator
     kinds = kinds or set()
     idx = 0
     while True:
+        if idx > len(_LOG_BUFFER):
+            idx = len(_LOG_BUFFER)
         while idx < len(_LOG_BUFFER):
             item = _LOG_BUFFER[idx]
             idx += 1
@@ -92,3 +130,27 @@ def get_auto_profile(stage: str) -> Set[str]:
     else:
         key = "data"
     return _PROFILES[key]
+
+
+def _append_event(event: Dict[str, object]) -> None:
+    kind = event["kind"]
+    buf = _KIND_BUFFERS[kind]
+    buf.append(event)
+    if len(buf) > MAX_PER_KIND:
+        old = buf.popleft()
+        try:
+            _LOG_BUFFER.remove(old)
+        except ValueError:
+            pass
+    _LOG_BUFFER.append(event)
+
+
+def recent_counts(window_secs: int = 30) -> Tuple[int, Dict[str, int]]:
+    cutoff = datetime.now(UTC) - timedelta(seconds=window_secs)
+    total = 0
+    counts: Dict[str, int] = defaultdict(int)
+    for item in list(_LOG_BUFFER):
+        if item["time"] >= cutoff:
+            total += 1
+            counts[item["kind"]] += 1
+    return total, dict(counts)


### PR DESCRIPTION
## Summary
- Add GPU-aware device utilities with sanity check and logging
- Introduce Stable-Baselines training heartbeat callback and error surfacing
- Show training progress and CUDA recommendations in the Streamlit UI
- Add credential input/verification panel with connection badges
- Limit log feed to last 200 events per category, coalescing slippage messages and summarizing recent activity

## Testing
- `pytest tests/test_log_stream.py -q`
- `pytest -q` *(fails: KeyError 'hybrid'; CalledProcessError in evaluate)*

------
https://chatgpt.com/codex/tasks/task_e_68a6587417888328902bd2b93c93fa93