### PR TITLE
feat: stream live training metrics

### DIFF
--- a/src/reports/human_friendly.py
+++ b/src/reports/human_friendly.py
@@ -8,7 +8,7 @@ This module provides two helpers:
 """
 
 from pathlib import Path
-from typing import Mapping, Sequence, Any
+from typing import Mapping, Sequence, Any, Dict
 
 import numpy as np
 
@@ -72,6 +72,29 @@ def write_readme(results: Mapping[str, Any], run_dir: Path) -> None:
         f"- Actividad: {turn:.2f} (cuánto mueve el bot)",
     ]
     (run_dir / "README.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def kpi_humano(metrics: Mapping[str, Any]) -> Dict[str, float]:
+    """Return key performance indicators with friendly Spanish names."""
+
+    pnl = float(metrics.get("pnl", 0.0))
+    dd = float(metrics.get("dd", metrics.get("max_drawdown", 0.0)))
+    rets: Sequence[float] | None = metrics.get("returns")  # type: ignore[assignment]
+    if rets is not None:
+        arr = np.asarray(rets, dtype=float)
+        consistency = float(arr.mean() / (arr.std(ddof=0) + 1e-12))
+    else:
+        consistency = float(metrics.get("sharpe", 0.0))
+    hit = float(metrics.get("hit", metrics.get("hit_ratio", 0.0)))
+    turn = float(metrics.get("orders", metrics.get("turnover", 0.0)))
+
+    return {
+        "Ganancia total": pnl,
+        "Caída máxima": dd,
+        "Consistencia": consistency,
+        "Acierto": hit,
+        "Actividad": turn,
+    }
 
 
 def render_panel(results: Mapping[str, Any]) -> None:

--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from queue import Queue
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from stable_baselines3.common.callbacks import BaseCallback
+except Exception:  # pragma: no cover - fallback when sb3 is missing
+    class BaseCallback:  # type: ignore
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def _on_step(self) -> bool:
+            return True
+
+from ..utils import paths
+
+
+class UiHeartbeatCallback(BaseCallback):
+    """Callback that emits training metrics to a queue and timeline file."""
+
+    def __init__(
+        self,
+        run_id: str,
+        queue: Queue | None = None,
+        *,
+        every_steps: int = 1000,
+    ) -> None:
+        super().__init__()
+        self.run_id = run_id
+        self.queue = queue
+        self.every_steps = every_steps
+        self._run_dir = paths.reports_dir() / f"run_{run_id}"
+        self._run_dir.mkdir(parents=True, exist_ok=True)
+        self._timeline = self._run_dir / "timeline.jsonl"
+
+    # ------------------------------------------------------------------
+    def _on_step(self) -> bool:  # type: ignore[override]
+        if self.num_timesteps % self.every_steps != 0:
+            return True
+
+        def _get(attr: str, default: float = 0.0) -> float:
+            try:
+                val = self.training_env.get_attr(attr)[0]
+                return float(val)
+            except Exception:
+                return float(default)
+
+        steps = int(self.num_timesteps)
+        reward_mean = _get("recent_reward_mean")
+        pnl = _get("equity")
+        peak = _get("equity_peak")
+        dd = (peak - pnl) / (peak + 1e-12)
+        hit = _get("hit_ratio")
+        orders = _get("n_orders", 0.0)
+        metrics = {
+            "steps": steps,
+            "reward_mean": reward_mean,
+            "pnl": pnl,
+            "dd": dd,
+            "hit": hit,
+            "orders": orders,
+        }
+
+        if self.queue is not None:
+            try:
+                self.queue.put_nowait(metrics)
+            except Exception:
+                pass
+
+        try:
+            with self._timeline.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(metrics) + "\n")
+        except Exception:
+            pass
+
+        return True

--- a/src/ui/progress_panel.py
+++ b/src/ui/progress_panel.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from queue import Queue, Empty
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from src.utils import paths
+from src.reports.human_friendly import kpi_humano
+
+
+def _load_timeline(run_dir: Path) -> pd.DataFrame:
+    path = run_dir / "timeline.jsonl"
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_json(path, lines=True)
+
+
+def _drain_queue(queue: Queue | None) -> list[dict]:
+    items: list[dict] = []
+    if queue is None:
+        return items
+    while True:
+        try:
+            items.append(queue.get_nowait())
+        except Empty:
+            break
+    return items
+
+
+def _render(df: pd.DataFrame) -> None:
+    if df.empty:
+        st.write("Sin datos")
+        return
+    latest = df.iloc[-1].to_dict()
+    kpis = kpi_humano(latest)
+    cols = st.columns(len(kpis))
+    for col, (name, val) in zip(cols, kpis.items()):
+        col.metric(name, f"{val:.4f}")
+    st.line_chart(df.set_index("steps")["pnl"])
+    if "orders" in df:
+        st.line_chart(df["orders"].diff().fillna(0))
+
+
+def show(queue: Queue | None, run_id: str) -> None:
+    """Render training/backtest progress in real time."""
+    run_dir = paths.reports_dir() / f"run_{run_id}"
+    train_tab, eval_tab = st.tabs(["Entrenamiento", "Evaluación"])
+    with train_tab:
+        df = _load_timeline(run_dir)
+        updates = _drain_queue(queue)
+        if updates:
+            df = pd.concat([df, pd.DataFrame(updates)], ignore_index=True)
+        _render(df)
+    with eval_tab:
+        df = _load_timeline(run_dir)
+        _render(df)


### PR DESCRIPTION
## Summary
- add `UiHeartbeatCallback` to emit training stats to a queue and timeline
- provide `kpi_humano` helper for human-readable KPIs
- introduce Streamlit progress panel showing live training/evaluation charts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec5d64708328a92e8c49bb472a27