### PR TITLE
Allow data preparation without Binance API keys and log data download progress

### DIFF
--- a/src/data/ccxt_loader.py
+++ b/src/data/ccxt_loader.py
@@ -81,7 +81,17 @@ def get_exchange(name: str | None = None, *, use_testnet: bool | None = None):
     if name and name.lower() != "binance":
         raise ValueError("only binance exchange is supported")
 
-    key, sec, env_testnet = load_binance_creds()
+    try:
+        key, sec, env_testnet = load_binance_creds()
+    except RuntimeError:
+        # Cuando no hay credenciales configuradas permitimos continuar con
+        # acceso solo a endpoints públicos.  Esto permite preparar datos
+        # básicos sin necesidad de claves de API.
+        key = ""
+        sec = ""
+        env_testnet = False
+        logger.warning("Credenciales Binance no configuradas; usando acceso público")
+
     use_testnet = env_testnet if use_testnet is None else use_testnet
 
     ex = ccxt.binance({"apiKey": key, "secret": sec, "enableRateLimit": True})
@@ -132,8 +142,19 @@ def fetch_ohlcv(
         if tf is None:  # pragma: no cover - unlikely for Binance
             raise ValueError("no supported timeframe found")
         logger.info("selected_timeframe=%s", tf)
-
-    data = exchange.fetch_ohlcv(symbol, timeframe=tf, since=since, limit=limit)
+    logger.info(
+        "fetching_ohlcv symbol=%s timeframe=%s since=%s limit=%s",
+        symbol,
+        tf,
+        since,
+        limit,
+    )
+    try:
+        data = exchange.fetch_ohlcv(symbol, timeframe=tf, since=since, limit=limit)
+    except Exception:
+        logger.exception("error_fetching_ohlcv symbol=%s timeframe=%s", symbol, tf)
+        raise
+    logger.info("fetched_rows=%d", len(data))
     df = pd.DataFrame(data, columns=["ts", "open", "high", "low", "close", "volume"])
     df.attrs["timeframe"] = tf
     return df

--- a/src/data/ensure.py
+++ b/src/data/ensure.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 from datetime import datetime, timedelta, UTC
 import time
 from pathlib import Path
+import logging
 
 import pandas as pd
 
 from ..utils.paths import raw_parquet_path
+
+
+logger = logging.getLogger(__name__)
 
 
 def ensure_ohlcv(
@@ -26,7 +30,9 @@ def ensure_ohlcv(
     """
 
     path = raw_parquet_path(exchange, symbol, timeframe)
+    logger.info("ensure_ohlcv path=%s", path)
     if path.exists():
+        logger.info("existing file found, skipping download")
         return path
 
     try:  # pragma: no cover - optional dependency
@@ -36,6 +42,13 @@ def ensure_ohlcv(
 
     ex_class = getattr(ccxt, exchange)
     ex = ex_class({"enableRateLimit": True})
+    logger.info(
+        "downloading OHLCV exchange=%s symbol=%s timeframe=%s hours=%d",
+        exchange,
+        symbol,
+        timeframe,
+        hours,
+    )
 
     since = int((datetime.now(UTC) - timedelta(hours=hours)).timestamp() * 1000)
     tf_ms = ex.parse_timeframe(timeframe) * 1000
@@ -46,19 +59,30 @@ def ensure_ohlcv(
         for attempt in range(5):
             try:
                 batch = ex.fetch_ohlcv(symbol, timeframe=timeframe, since=since)
+                logger.info(
+                    "fetched batch rows=%d since=%d attempt=%d",
+                    len(batch),
+                    since,
+                    attempt + 1,
+                )
                 break
             except ccxt.RateLimitExceeded:  # pragma: no cover - network
+                logger.warning("rate limit exceeded, retrying...", exc_info=True)
                 time.sleep(2 ** attempt)
         else:  # pragma: no cover - network
+            logger.error("rate limit exceeded fetching OHLCV")
             raise RuntimeError("rate limit exceeded fetching OHLCV")
 
         if not batch:
+            logger.warning("empty batch received, stopping download")
             break
         rows.extend(batch)
         since = batch[-1][0] + tf_ms
 
     if not rows:
+        logger.error("no OHLCV data downloaded for %s %s", exchange, symbol)
         raise RuntimeError("no OHLCV data downloaded")
+    logger.info("download complete rows=%d", len(rows))
 
     df = pd.DataFrame(rows, columns=["ts", "open", "high", "low", "close", "volume"])
     df["exchange"] = exchange
@@ -67,5 +91,6 @@ def ensure_ohlcv(
     df["source"] = "ccxt"
 
     path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("saving parquet to %s", path)
     df.to_parquet(path)
     return path

--- a/src/data/pipeline.py
+++ b/src/data/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Callable, List
+import logging
 
 from .ccxt_loader import get_exchange, fetch_ohlcv
 from .symbol_discovery import discover_symbols
@@ -10,6 +11,9 @@ from .ensure import ensure_ohlcv
 from .incremental import update_all
 from .refresh_worker import start_refresh_worker
 from .microv5_loader import MicroV5Collector
+
+
+logger = logging.getLogger(__name__)
 
 
 def prepare_data(
@@ -25,6 +29,7 @@ def prepare_data(
     def report(msg: str) -> None:
         if progress_cb:
             progress_cb(msg)
+        logger.info(msg)
 
     ex = get_exchange()
     report("Descubriendo…")

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -123,7 +123,7 @@ else:
     if badge == "CPU (PyTorch sin CUDA)":
         with st.sidebar.expander("¿Cómo habilitar CUDA?"):
             st.markdown(
-                "Instala PyTorch con soporte CUDA, por ejemplo: `pip install torch --index-url https://download.pytorch.org/whl/cu118`"
+                "Instala PyTorch con soporte CUDA, por ejemplo: `pip install torch --index-url https://download.pytorch.org/whl/cu121`"
             )
 
 with st.sidebar:


### PR DESCRIPTION
## Summary
- allow public-only Binance access in ccxt_loader when API keys are missing
- update Streamlit sidebar to suggest installing the CUDA 12.1 torch wheels
- log OHLCV fetching and ensure_ohlcv progress for easier debugging

## Testing
- `pytest tests/test_pipeline.py tests/test_data_loader_smoke.py tests/test_stream_smoke.py tests/test_microv5_loader.py tests/test_binance_meta.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fc564c3483288d7717c14f2805a1